### PR TITLE
docs: adiciona arquivo LICENSE (MIT) que faltava

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Caio Ross
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Contexto
O `README.md` declara licença **MIT** em três pontos — badge (linha 18), prosa PT (linha 224) e EN (linha 325) — todos com link relativo para `LICENSE`. O arquivo, porém, não existia: os links davam **404** no GitHub e, num repo **público**, a base ficava sem licença efetiva (copyright padrão), contradizendo a promessa do README.

## O que mudou e por quê
- Cria **`LICENSE`** na raiz com o texto **padrão MIT** (SPDX `MIT`), cabeçalho `Copyright (c) 2023 Caio Ross` (ano do projeto original, conforme acceptance criteria).
- Nome exato `LICENSE` (sem extensão) para casar com os links do README — os três passam a resolver.
- **Nenhum código-fonte tocado**; diff = 1 arquivo novo.

Não é `decisao-dono`: a licença MIT já foi escolhida e publicada pelo próprio dono no README; esta PR apenas materializa o arquivo que faltava para bater com a intenção declarada.

## Resultado do gate
`node scripts/gate.mjs` → **GATE VERDE — 19/19** (LICENSE é arquivo estático; não afeta data model nem Brusher).

## Riscos
Nenhum funcional. Único ponto de atenção: se o dono quiser OUTRA licença ou outro ano/titular, é só ajustar o cabeçalho — aí vira `decisao-dono`.

Closes #18