### PR TITLE
fix(a11y): anel de foco visivel no input do chat

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -368,6 +368,7 @@ button { font-family: var(--font-body); cursor: pointer; }
   padding: 1rem 1.25rem; resize: none; min-height: 58px; max-height: 120px;
   outline: none; letter-spacing: 0.02em; overflow-y: auto;
 }
+.action-box-input:focus-visible { outline: 2px solid var(--gold); outline-offset: -2px; }
 .action-box-input::placeholder { color: var(--text-dim); font-style: italic; }
 .action-box-submit {
   width: 58px; min-height: 58px; background: var(--gold); border: none;


### PR DESCRIPTION
## Contexto
O input principal do chat (`.action-box-input`, `css/styles.css:365-370`) define `outline: none` e não tinha nenhuma regra `:focus`/`:focus-visible` — usuários de teclado/leitor de tela não recebiam sinal visual de foco no elemento mais central do site. Fecha #16.

## O que mudou e por quê
Uma única linha de CSS, logo após a declaração do input:

```css
.action-box-input:focus-visible { outline: 2px solid var(--gold); outline-offset: -2px; }
```

- Espelha o padrão já existente em `.p-card:focus-visible` (linha 434) — dourado `var(--gold)`, coerência visual.
- `outline-offset: -2px` mantém o anel **dentro** da caixa, já que o input é `flex:1` colado ao botão de enviar (evita corte/sobreposição na borda direita).
- `:focus-visible` (não `:focus`) → o anel **não** reaparece ao clicar com o mouse, preservando a estética limpa vintage.
- Botão `.action-box-submit` deixado como está: não tem `outline: none`, então mantém o foco nativo do browser; um anel dourado nele seria dourado-sobre-dourado (regressão de contraste). Escopo honesto = só o input.

## Acceptance criteria
- [x] `.action-box-input:focus-visible` com anel dourado coerente com `.p-card:focus-visible`.
- [x] Foco não reaparece no clique de mouse (`:focus-visible`).
- [x] Contraste WCAG: dourado `#c9a84c` sobre `--bg-card-2` `#14141f` (claro sobre escuro, alto contraste).
- [x] Sem regressão no `.action-box` (borda superior e botão intactos; diff de 1 linha).
- [x] Gate verde.

## Gate (resultado real)
`node scripts/gate.mjs` → **GATE VERDE — 19/19 checagens passaram.**

## Teste manual sugerido
Abrir a página, dar **Tab** até o input do chat: anel dourado de 2px aparece dentro da caixa. Clicar com o mouse no input: **sem** anel. Tema vintage e efeito Brusher intactos.

## Riscos
Mínimos — CSS puro, uma regra nova, área sagrada não tocada (HANDBOOK §7.3, mergeável normal).

Closes #16