### PR TITLE
fix(a11y): coverflow da gôndola respeita prefers-reduced-motion

### DIFF
--- a/js/mainJs.js
+++ b/js/mainJs.js
@@ -39,6 +39,14 @@
     });
   }
   function clamp(v, a, b) { return Math.max(a, Math.min(b, v)); }
+
+  /* Preferência de movimento reduzido (a11y) — reativa a mudanças do SO */
+  var reduceMotionMQ = window.matchMedia ? window.matchMedia('(prefers-reduced-motion: reduce)') : null;
+  function prefersReducedMotion() { return !!(reduceMotionMQ && reduceMotionMQ.matches); }
+  function motionBehavior() { return prefersReducedMotion() ? 'auto' : 'smooth'; }
+  if (reduceMotionMQ && reduceMotionMQ.addEventListener) {
+    reduceMotionMQ.addEventListener('change', function () { updateGondola(); });
+  }
   function getTime() {
     var d = new Date(), m = d.getMinutes();
     return d.getHours() + ':' + (m < 10 ? '0' : '') + m;
@@ -353,19 +361,28 @@
     if (!cards.length) return;
     var vpCenter = track.scrollLeft + track.clientWidth / 2;
     var nearest = null, nearestDist = Infinity;
+    var reduced = prefersReducedMotion();
 
     cards.forEach(function (card) {
       var cardCenter = card.offsetLeft + card.offsetWidth / 2;
       var dist = cardCenter - vpCenter;
-      var norm = dist / card.offsetWidth;
-      var a = Math.abs(norm);
-      var scale = clamp(1 - a * 0.16, 0.72, 1);
-      var rot   = clamp(-norm * 24, -45, 45);
-      var tz    = -Math.min(a, 3) * 70;
-      var op    = clamp(1 - a * 0.34, 0.30, 1);
-      card.style.transform = 'translateZ(' + tz.toFixed(1) + 'px) rotateY(' + rot.toFixed(1) + 'deg) scale(' + scale.toFixed(3) + ')';
-      card.style.opacity = op.toFixed(2);
-      card.style.zIndex = String(200 - Math.round(a * 12));
+      if (reduced) {
+        // Movimento reduzido: caminho plano, sem rotateY/translateZ/scale nem dim.
+        // Cards ficam legíveis; o realce do selecionado vem só da classe .is-active.
+        card.style.transform = 'none';
+        card.style.opacity = '';
+        card.style.zIndex = '';
+      } else {
+        var norm = dist / card.offsetWidth;
+        var a = Math.abs(norm);
+        var scale = clamp(1 - a * 0.16, 0.72, 1);
+        var rot   = clamp(-norm * 24, -45, 45);
+        var tz    = -Math.min(a, 3) * 70;
+        var op    = clamp(1 - a * 0.34, 0.30, 1);
+        card.style.transform = 'translateZ(' + tz.toFixed(1) + 'px) rotateY(' + rot.toFixed(1) + 'deg) scale(' + scale.toFixed(3) + ')';
+        card.style.opacity = op.toFixed(2);
+        card.style.zIndex = String(200 - Math.round(a * 12));
+      }
       if (Math.abs(dist) < nearestDist) { nearestDist = Math.abs(dist); nearest = card; }
     });
 
@@ -382,14 +399,14 @@
   function centerCard(card) {
     if (!card || !track) return;
     var target = card.offsetLeft + card.offsetWidth / 2 - track.clientWidth / 2;
-    track.scrollTo({ left: target, behavior: 'smooth' });
+    track.scrollTo({ left: target, behavior: motionBehavior() });
   }
   function scrollByCards(dir) {
     if (!track) return;
     var cards = track.querySelectorAll('.gondola-card');
     if (cards.length < 2) return;
     var step = cards[1].offsetLeft - cards[0].offsetLeft;
-    track.scrollBy({ left: dir * step, behavior: 'smooth' });
+    track.scrollBy({ left: dir * step, behavior: motionBehavior() });
   }
 
   function confirmSelection() {


### PR DESCRIPTION
## Contexto

O modal "Gôndola" (coverflow 3D) escrevia os transforms de perspectiva como **inline style** em cada card a cada scroll (`updateGondola()` em `js/mainJs.js`). O bloco `@media (prefers-reduced-motion: reduce)` do CSS (`css/styles.css:711`) só neutraliza `animation`/`transition`, **não** inline styles — então usuários com movimento reduzido no SO continuavam vendo os cards girarem em 3D, encolherem e mudarem de opacidade. Com o site LIVE no GitHub Pages, isso vale para visitantes reais com sensibilidade vestibular.

## O que mudou (`js/mainJs.js`, +28/-11)

- **`updateGondola()`**: quando `prefers-reduced-motion: reduce` está ativo, aplica um **caminho plano** — `transform:none`, `opacity`/`zIndex` resetados (CSS base de `.gondola-card` não define transform/opacity, então os cards ficam planos e legíveis). O cálculo de `nearest` e o toggle de `.is-active` (+ `setSelected`) ficam **intactos** — seleção e "Selecionado: ..." seguem funcionando; o realce do card central vem só da classe `.is-active` (borda dourada).
- **Reativo em runtime**: `matchMedia('(prefers-reduced-motion: reduce)')` com listener de `change` re-renderiza a gôndola sem exigir reload.
- **Scroll**: `centerCard`/`scrollByCards` passam a usar `behavior:'auto'` sob `reduce` (via helper `motionBehavior()`), removendo a sobreposição do smooth-scroll JS ao `scroll-behavior:auto` que o CSS já declarava para `.gondola-track` (`css/styles.css:713`) — fecha uma inconsistência existente no mesmo contrato de reduced-motion.

**Sem `reduce` (padrão), o coverflow é byte-idêntico ao anterior** (o bloco `else` é o código original) — tema/experiência vintage preservada (HANDBOOK §2). Brusher, tema dark vintage e zero-build intocados.

## Teste manual (visual)

1. DevTools → Rendering → **Emulate CSS media: `prefers-reduced-motion: reduce`**.
2. Abrir a gôndola e rolar → cards ficam **planos**, sem rotação 3D / mudança de escala / dim por distância; ainda legíveis. Card central recebe `.is-active` e alimenta "Selecionado: ...".
3. Desativar a emulação → coverflow volta idêntico ao atual.
4. Alternar a emulação com a gôndola aberta → atualiza sem reload (listener de `change`).

## Gate

`node scripts/gate.mjs` → **GATE VERDE — 19/19 checagens passaram.**

## Riscos

Baixo. Mudança isolada na renderização visual da gôndola; nenhuma alteração no fluxo do chat/OpenAI. O caminho default é o código original preservado.

Closes #14