### PR TITLE
feat(conteudo): starters por personagem + fallback; curadoria de Ciência

### DIFF
--- a/js/mainJs.js
+++ b/js/mainJs.js
@@ -84,7 +84,8 @@
     wb.textContent = 'Você está diante de ' + p.name + ' — ' + p.tagline + '. Faça sua pergunta...';
     block.appendChild(wb);
     var chips = document.createElement('div'); chips.className = 'starter-chips';
-    STARTERS.forEach(function (q) {
+    var list = (p.starters && p.starters.length) ? p.starters : STARTERS;
+    list.forEach(function (q) {
       var b = document.createElement('button');
       b.type = 'button'; b.className = 'starter-chip'; b.textContent = q;
       b.addEventListener('click', function () {

--- a/js/personalities.js
+++ b/js/personalities.js
@@ -49,13 +49,13 @@
   /* ── Personagens (img = null → monograma gerado) ── */
   var PEOPLE = [
     /* Ciência & Tecnologia */
-    { name: 'Albert Einstein',        cat: 'ciencia',   years: '1879–1955',     tagline: 'Pai da Relatividade',          img: 'persons/Albert Einstein.jpg' },
-    { name: 'Isaac Newton',           cat: 'ciencia',   years: '1643–1727',     tagline: 'As Leis do Movimento',         img: 'persons/Isaac Newton.jpg' },
-    { name: 'Nikola Tesla',           cat: 'ciencia',   years: '1856–1943',     tagline: 'O Gênio da Eletricidade',      img: 'persons/Nikola Tesla.jpg' },
-    { name: 'Thomas Edison',          cat: 'ciencia',   years: '1847–1931',     tagline: 'O Mago de Menlo Park',         img: 'persons/Thomas Edison.jpg' },
-    { name: 'Charles Darwin',         cat: 'ciencia',   years: '1809–1882',     tagline: 'A Origem das Espécies',        img: null },
-    { name: 'Galileu Galilei',        cat: 'ciencia',   years: '1564–1642',     tagline: 'Pai da Ciência Moderna',       img: null },
-    { name: 'Steve Jobs',             cat: 'ciencia',   years: '1955–2011',     tagline: 'O Visionário da Apple',        img: null },
+    { name: 'Albert Einstein',        cat: 'ciencia',   years: '1879–1955',     tagline: 'Pai da Relatividade',          img: 'persons/Albert Einstein.jpg', starters: ['Como o senhor imaginou viajar ao lado de um raio de luz?', 'O que sentiu ao saber que o eclipse de 1919 confirmou sua teoria?', 'Por que o senhor dizia que Deus não joga dados?'] },
+    { name: 'Isaac Newton',           cat: 'ciencia',   years: '1643–1727',     tagline: 'As Leis do Movimento',         img: 'persons/Isaac Newton.jpg', starters: ['É verdade que uma maçã o inspirou a pensar na gravidade?', 'Como foi decompor a luz branca com um prisma?', 'O que significou para o senhor estar sobre ombros de gigantes?'] },
+    { name: 'Nikola Tesla',           cat: 'ciencia',   years: '1856–1943',     tagline: 'O Gênio da Eletricidade',      img: 'persons/Nikola Tesla.jpg', starters: ['Por que o senhor defendia a corrente alternada contra Edison?', 'Como imaginava transmitir energia sem fios em Wardenclyffe?', 'O que via nas suas visões vívidas de máquinas completas?'] },
+    { name: 'Thomas Edison',          cat: 'ciencia',   years: '1847–1931',     tagline: 'O Mago de Menlo Park',         img: 'persons/Thomas Edison.jpg', starters: ['Quantas tentativas foram precisas até a lâmpada incandescente funcionar?', 'O que o senhor queria dizer com 1% de inspiração e 99% de transpiração?', 'Como era dirigir o laboratório de Menlo Park?'] },
+    { name: 'Charles Darwin',         cat: 'ciencia',   years: '1809–1882',     tagline: 'A Origem das Espécies',        img: null, starters: ['O que o senhor observou nos tentilhões das Galápagos?', 'Por que hesitou tantos anos antes de publicar A Origem das Espécies?', 'Como foi a viagem a bordo do Beagle?'] },
+    { name: 'Galileu Galilei',        cat: 'ciencia',   years: '1564–1642',     tagline: 'Pai da Ciência Moderna',       img: null, starters: ['O que o senhor viu ao apontar sua luneta para Júpiter?', 'Como foi enfrentar a Inquisição por defender Copérnico?', 'É verdade que sussurrou Eppur si muove depois do julgamento?'] },
+    { name: 'Steve Jobs',             cat: 'ciencia',   years: '1955–2011',     tagline: 'O Visionário da Apple',        img: null, starters: ['O que te levou a voltar à Apple em 1997?', 'Por que a simplicidade era tão importante no seu design?', 'Como foi apresentar o primeiro iPhone em 2007?'] },
 
     /* Arte & Literatura */
     { name: 'Leonardo da Vinci',      cat: 'arte',      years: '1452–1519',     tagline: 'O Gênio Renascentista',        img: null },


### PR DESCRIPTION
## Contexto
Os *conversation starters* (chips da tela de boas-vindas) eram **estáticos e idênticos** para as 47 personalidades (`js/mainJs.js` array `STARTERS`), quebrando a imersão. Esta fatia entrega o **mecanismo** + curadoria da **1ª categoria (Ciência & Tecnologia)**, exatamente como a issue delimitou para não virar epic.

## O que mudou e por quê
- **`js/personalities.js`** (fonte única de verdade): campo **opcional** `starters` (3 perguntas cada) nos 7 de `cat:'ciencia'` — Einstein, Newton, Tesla, Edison, Darwin, Galileu, Steve Jobs. Perguntas em **2ª pessoa**, PT-BR, **historicamente plausíveis** e específicas da pessoa (ex.: eclipse de 1919 p/ Einstein; luas de Júpiter p/ Galileu; iPhone 2007 p/ Jobs). Nenhum campo obrigatório novo → gate inalterado.
- **`js/mainJs.js`** (`showWelcome`, 1 linha aditiva): `var list = (p.starters && p.starters.length) ? p.starters : STARTERS;` e itera `list`. Quem não tem `starters` cai nos 3 genéricos — **comportamento atual 100% preservado**. Render segue via `textContent` (sem HTML injetável).

## Acceptance criteria
- [x] 7 personagens de `ciencia` com `starters` (3 perguntas, específicas, plausíveis, PT-BR, 2ª pessoa)
- [x] `showWelcome()` usa `p.starters` quando presente; **fallback** nos genéricos quando ausente (verificado nas 5 personalidades de Música — todas sem starters)
- [x] Chips continuam funcionais (clique → `insertMessage()`); texto seguro (`textContent`)
- [x] `node scripts/gate.mjs` **verde**

## Resultado real do gate
`GATE VERDE — 19/19 checagens passaram.` (rodado no worktree)

Verificação funcional extra (Node, carregando `NostalgiaData`): 7/7 de Ciência com 3 starters únicos; 5/5 de Música sem starters (fallback OK); total 47 pessoas.

> ℹ️ O validador `nostalgia-content/scripts/validar_personalidade.py` **não parseia** o `personalities.js` real (modelo antigo `id`/`category`/categorias em inglês) — é a divergência já rastreada na **#10**, pré-existente e independente deste diff. O gate é a autoridade aqui.

## Classificação (HANDBOOK §7)
**Normal (§7.3)** — conteúdo novo validado + correção pequena e testada de JS. Não é núcleo (sem segredo/Brusher/tema/zero-build/dependência/deploy). Toca `mainJs.js` de forma **aditiva** no render de boas-vindas (não no fluxo OpenAI nem remove/renomeia personalidade), então fora do rol §7.2 — mas sinalizo o toque em `mainJs.js` para o PR Doctor decidir quórum se julgar.

## Riscos
Baixo: mudança aditiva e retrocompatível; sem novas dependências; sem alteração no fluxo de chat/OpenAI nem em áreas sagradas.

## Teste manual sugerido
Abrir `index.html`, entrar no chat de **Einstein** → ver os 3 chips específicos; entrar em qualquer personagem de **Música** → ver os 3 chips genéricos de sempre. Clicar num chip preenche o input e envia.

Refs #24