### PR TITLE
fix(chat): lock de reentrância e cancelamento da requisição em voo (#27)

### DIFF
--- a/js/mainJs.js
+++ b/js/mainJs.js
@@ -26,6 +26,7 @@
   var currentPerson = null;
   var conversation  = [];      // {role, content}
   var pendingSlug   = null;    // seleção dentro do modal
+  var pending       = null;    // requisição OpenAI em voo: { controller, timeoutId, cancelled }
   var state         = { cat: 'all', q: '' };
 
   /* Refs (atribuídas no init) */
@@ -119,6 +120,7 @@
   }
   function showTyping() {
     var c = getMessages(); if (!c) return;
+    hideTyping();               // garante no máximo um #typing-row no DOM
     clearWelcome(c);
     var row = document.createElement('div'); row.className = 'msg-row remote'; row.id = 'typing-row';
     var av = document.createElement('div'); av.className = 'msg-avatar';
@@ -130,6 +132,14 @@
     row.appendChild(av); row.appendChild(bubble); c.appendChild(row); scrollToBottom();
   }
   function hideTyping() { var el = document.getElementById('typing-row'); if (el) el.remove(); }
+
+  /* Bloqueia/desbloqueia o envio enquanto há uma resposta em voo (lock visível ao usuário). */
+  function setChatBusy(busy) {
+    var input = document.getElementById('chat-input');
+    var btn   = document.querySelector('.action-box-submit');
+    if (input) input.disabled = busy;
+    if (btn)   btn.disabled   = busy;
+  }
 
   function buildSystemPrompt(p) {
     return [
@@ -168,6 +178,7 @@
   window.insertMessage = function () {
     var input = document.getElementById('chat-input');
     if (!input || !currentPerson) return;
+    if (pending) return;         // já há uma resposta em voo — ignora o novo envio (lock)
     var msgText = input.value.trim();
     if (!msgText) return;
 
@@ -180,9 +191,19 @@
       .concat(conversation.slice(-10));
 
     /* Timeout via AbortController (vanilla; sem dependência). Falha silenciosa
-       de rede vira AbortError após OPENAI_TIMEOUT ms. */
+       de rede vira AbortError após OPENAI_TIMEOUT ms. O controller vive em `pending`
+       (estado de módulo) para que applyPerson() possa abortar ao trocar de personagem. */
     var controller = (typeof AbortController !== 'undefined') ? new AbortController() : null;
-    var timeoutId  = controller ? setTimeout(function () { controller.abort(); }, OPENAI_TIMEOUT) : null;
+    var req = { controller: controller, timeoutId: null, cancelled: false };
+    req.timeoutId = controller ? setTimeout(function () { controller.abort(); }, OPENAI_TIMEOUT) : null;
+    pending = req;
+    setChatBusy(true);
+
+    /* Encerra a requisição: limpa o timeout e libera o lock se ainda for a atual. */
+    function done() {
+      if (req.timeoutId) { clearTimeout(req.timeoutId); req.timeoutId = null; }
+      if (pending === req) { pending = null; setChatBusy(false); }
+    }
 
     fetch('https://api.openai.com/v1/chat/completions', {
       method: 'POST',
@@ -201,7 +222,7 @@
       signal: controller ? controller.signal : undefined
     })
       .then(function (res) {
-        if (timeoutId) { clearTimeout(timeoutId); timeoutId = null; }
+        if (req.timeoutId) { clearTimeout(req.timeoutId); req.timeoutId = null; }
         if (!res.ok) return res.text().then(function (t) {
           var e = new Error('HTTP ' + res.status + ' — ' + t);
           e.status = res.status;
@@ -210,6 +231,8 @@
         return res.json();
       })
       .then(function (data) {
+        if (req.cancelled) { done(); return; }   // trocou de personagem — descarta a resposta antiga
+        done();
         hideTyping();
         var text = (data.choices && data.choices[0] && data.choices[0].message &&
           data.choices[0].message.content) ? data.choices[0].message.content.trim() : '';
@@ -218,7 +241,8 @@
         appendAIMessage(text);
       })
       .catch(function (err) {
-        if (timeoutId) { clearTimeout(timeoutId); timeoutId = null; }
+        if (req.cancelled) { done(); return; }    // abort intencional (troca de personagem) — silêncio
+        done();
         hideTyping();
         appendAIMessage(chatErrorMessage(err));
         console.error('[NostalgiaGPT]', err);
@@ -235,6 +259,15 @@
   }
   function applyPerson(p, scroll) {
     if (!p) return;
+    /* Cancela a resposta em voo do personagem anterior: marca como intencional
+       (o catch/then a ignora em silêncio) e libera o lock antes de trocar. */
+    if (pending) {
+      pending.cancelled = true;
+      if (pending.timeoutId) { clearTimeout(pending.timeoutId); pending.timeoutId = null; }
+      if (pending.controller) pending.controller.abort();
+      pending = null;
+      setChatBusy(false);
+    }
     currentPerson = p;
     if (avatarSlot) avatarSlot.innerHTML = avatarHTML(p) + '<div class="avatar-ring"></div>';
     if (nameEl) nameEl.textContent = p.name;


### PR DESCRIPTION
## Contexto

`window.insertMessage` disparava o `fetch` da OpenAI sem controle de ciclo de vida: sem guarda de reentrância e com o `AbortController` preso em variável local. Isso causava (issue #27) envios concorrentes (múltiplos `#typing-row` com mesmo `id`, histórico fora de ordem, chamadas pagas em paralelo) e resposta do personagem antigo vazando para o novo ao trocar na gôndola.

## O que mudou e por quê

`js/mainJs.js` (único arquivo tocado, +37/-4):

1. **Estado de módulo `pending`** (`{ controller, timeoutId, cancelled }`) ao lado de `conversation`/`currentPerson` — dá controle de ciclo de vida à requisição.
2. **Lock de reentrância**: `insertMessage` retorna cedo se `pending` existir, e `setChatBusy(true)` desabilita `#chat-input` + `.action-box-submit` (estado `disabled` nativo — bloqueio visível). Cobre todos os pontos de entrada (Enter, botão, starter chips).
3. **Cancelamento na troca de personagem**: `applyPerson` marca `pending.cancelled = true`, aborta o controller e libera o lock. O handler `.then`/`.catch` da requisição antiga vê `cancelled` e descarta em silêncio — nada é renderizado nem entra no `conversation` do novo personagem.
4. **Silêncio no cancelamento intencional**: o guard `cancelled` fica **antes** do `appendAIMessage`, distinguindo-o do `AbortError` de timeout (que mantém `cancelled = false` e segue exibindo a mensagem de `chatErrorMessage`).
5. **Invariante do typing-row**: `showTyping` chama `hideTyping()` primeiro → `document.querySelectorAll('#typing-row').length <= 1` por construção.

## Acceptance criteria (#27)

- [x] Novo envio com resposta em voo não dispara 2º `fetch` (lock + input/botão desabilitados, visível).
- [x] Nunca mais de um `#typing-row` no DOM.
- [x] `applyPerson()` aborta a pendente; resposta antiga não é renderizada nem entra no `conversation` novo.
- [x] Abort por troca de personagem não exibe erro no chat (distinto do timeout).
- [x] Timeout de 30s (`OPENAI_TIMEOUT`) intacto.
- [x] `node scripts/gate.mjs` verde.

## Resultado do gate (real)

`node scripts/gate.mjs` → **GATE VERDE — 19/19 checagens passaram** (rodado no worktree). Não toca `js/personalities.js`.

## Teste manual sugerido (fluxo depende de chave OpenAI real; placeholder no repo)

Com uma chave válida em `OPENAI_KEY`:
1. **Lock**: envie uma pergunta e, antes da resposta, tente enviar outra (Enter/botão/chip) → input e botão ficam desabilitados; nenhum 2º balão "digitando" surge; só uma resposta chega, na ordem.
2. **Troca de personagem**: envie para Cleópatra → antes da resposta, troque para Einstein na gôndola → a resposta de Cleópatra **não** aparece, não há avatar trocado nem mensagem de erro, e o chat do Einstein começa limpo.
3. **Timeout**: (opcional) reduza `OPENAI_TIMEOUT` e verifique que a mensagem ⌛ ainda aparece normalmente.

## Riscos

Baixo, escopo restrito ao fluxo de envio. Fallback sem `AbortController` preservado (resposta ainda é descartada via flag `cancelled`, sem regressão). Nenhuma dependência nova, zero-build mantido.

Toca o fluxo do chat/OpenAI → **Solicito quórum (HANDBOOK §7)**.

Closes #27
