### PR TITLE
docs: link para o demo ao vivo no README (#34)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@
 
 <br/>
 
+[![Ver ao vivo · Live demo](https://img.shields.io/badge/▶_Ver_ao_vivo_·_Live_demo-caioross.github.io-c9a84c?style=for-the-badge)](https://caioross.github.io/NostalgiaGPT/)
+
+<br/>
+
 [![HTML5](https://img.shields.io/badge/HTML5-E34F26?style=for-the-badge&logo=html5&logoColor=white)](https://developer.mozilla.org/pt-BR/docs/Web/HTML)
 [![CSS3](https://img.shields.io/badge/CSS3-1572B6?style=for-the-badge&logo=css3&logoColor=white)](https://developer.mozilla.org/pt-BR/docs/Web/CSS)
 [![JavaScript](https://img.shields.io/badge/JavaScript-F7DF1E?style=for-the-badge&logo=javascript&logoColor=black)](https://developer.mozilla.org/pt-BR/docs/Web/JavaScript)
@@ -35,6 +39,8 @@
 ---
 
 ## 🇧🇷 Português
+
+🔗 **Acesse ao vivo:** [caioross.github.io/NostalgiaGPT](https://caioross.github.io/NostalgiaGPT/) — experimente sem instalar nada.
 
 ### O que é
 
@@ -234,6 +240,8 @@ Distribuído sob a [licença MIT](LICENSE). Use, modifique e distribua à vontad
 ---
 
 ## 🇺🇸 English
+
+🔗 **Live demo:** [caioross.github.io/NostalgiaGPT](https://caioross.github.io/NostalgiaGPT/) — try it with nothing to install.
 
 ### What it is
 


### PR DESCRIPTION
## Contexto

O site está LIVE em https://caioross.github.io/NostalgiaGPT/ (verificado nesta rodada: `HTTP 200`), mas o `README.md` — a porta de entrada do repo público — não tinha nenhum link para o demo. Quem chegava precisava clonar e rodar local para experimentar. Resolve #34.

## O que mudou (só `README.md`)

- **Badge proeminente acima da dobra**: `▶ Ver ao vivo · Live demo` (dourado `c9a84c` do tema, `style=for-the-badge`), logo abaixo do tagline e antes dos badges de tecnologia — é o primeiro badge que o visitante vê.
- **Seção 🇧🇷 Português**: linha `🔗 **Acesse ao vivo:** …` no início.
- **Seção 🇺🇸 English**: linha `🔗 **Live demo:** …` no início, rótulo no idioma correto.
- Todos os links apontam para `https://caioross.github.io/NostalgiaGPT/` (com barra final).

## Acceptance criteria

- [x] Link proeminente acima da dobra no bloco de badges do topo.
- [x] Ambas as seções de idioma mencionam o link, com rótulo no idioma correto.
- [x] URL exata do Pages com barra final; resolve `HTTP 200` (verificado via `curl`).
- [x] Só edição de `README.md`; nada de tema/Brusher/gate.

## Gate (resultado real)

`node scripts/gate.mjs` → **GATE VERDE — 19/19 checagens passaram.**

## Riscos

Mínimos: mudança puramente documental, 8 linhas inseridas, nenhum arquivo de código ou área sagrada tocado. O gate não valida README (rodado só para garantir que nada quebrou).

Closes #34
