### PR TITLE
fix: setas ←/→ não sequestram o caret do campo de busca da gôndola (#31)

### DIFF
--- a/js/mainJs.js
+++ b/js/mainJs.js
@@ -472,8 +472,8 @@
   }
   function onPickerKey(e) {
     if (e.which === 27) { e.preventDefault(); closePicker(); }
-    else if (e.which === 37) { e.preventDefault(); scrollByCards(-1); }
-    else if (e.which === 39) { e.preventDefault(); scrollByCards(1); }
+    else if (e.which === 37 && document.activeElement !== searchInput) { e.preventDefault(); scrollByCards(-1); }
+    else if (e.which === 39 && document.activeElement !== searchInput) { e.preventDefault(); scrollByCards(1); }
     else if (e.which === 13 && document.activeElement === searchInput) { e.preventDefault(); confirmSelection(); }
   }
 


### PR DESCRIPTION
## Contexto

No modal "Gôndola", `onPickerKey` (`js/mainJs.js:473-478`) capturava ←/→ (`which` 37/39) com `preventDefault()` + `scrollByCards(±1)` **incondicionalmente**. Como o foco vai para `#picker-search` ao abrir o modal (`mainJs.js:464`), o fluxo mais comum (abrir → digitar → corrigir com ←) ficava quebrado: o caret não se movia, a gôndola rolava, e `Shift+←/→` (seleção) era engolido.

## O que mudou e por quê

Diff de 2 linhas: os branches de 37/39 agora só rolam o coverflow quando `document.activeElement !== searchInput`. Reaproveita a **mesma guarda** que o branch do Enter já usa (`mainJs.js:477`), mantendo o idioma do arquivo e o diff mínimo. Com foco na busca, as setas caem no comportamento padrão do input (mover caret, selecionar com Shift); fora dele (cards/body), a navegação da gôndola segue igual.

## Acceptance criteria

- [x] Foco em `#picker-search`: ←/→ movem o caret e Shift+←/→ selecionam (gôndola não rola)
- [x] Foco fora do campo: ←/→ continuam rolando o coverflow
- [x] Esc e Enter no campo de busca inalterados (`mainJs.js:474,477`)
- [x] `node scripts/gate.mjs` verde

## Gate (resultado real)

`GATE VERDE — 19/19 checagens passaram.`

## Teste manual sugerido

Abrir a gôndola, clicar/digitar no campo de busca "einsten", posicionar o caret e pressionar ← → e Shift+←: o caret deve editar/selecionar sem rolar os cards. Depois clicar num card (tirar foco do input) e usar ←/→: o coverflow deve rolar normalmente.

## Riscos

Baixo. Não toca no fluxo de chat/OpenAI nem em área sagrada (Brusher/tema/zero-build). Alteração isolada no handler de teclado do picker.

## Classificação

HANDBOOK §7.3 (normal) — correção pequena e testada de JS, fora do fluxo de chat/OpenAI.

Closes #31