### PR TITLE
docs(fleet): HANDBOOK §2 reflete Pages LIVE — main = produção

### DIFF
--- a/docs/fleet/HANDBOOK.md
+++ b/docs/fleet/HANDBOOK.md
@@ -46,10 +46,15 @@ personalidades históricas** via OpenAI Chat Completions (`gpt-4o-mini`).
 
 ### Produção
 
-GitHub Pages **ainda não está habilitado** (decisão do dono — depende do P0 da
-chave OpenAI/backend proxy). Enquanto Pages estiver desligado, merge na main NÃO
-derruba produção; ainda assim, main quebrada é inaceitável (é a vitrine do repo).
-Quando Pages for ligado, main = LIVE e o rigor sobe.
+GitHub Pages **está habilitado**, servindo `main` na raiz (`/`). O site 2026 está
+LIVE em <https://caioross.github.io/NostalgiaGPT/>. Ou seja: **`main` = produção** —
+todo merge na `main` vai direto ao ar. O rigor é o mais alto: **main quebrada = site
+fora do ar** (não só a vitrine do repo). O PR Doctor lê o diff inteiro antes de
+mergear e o gate verde é obrigatório — sem enfraquecer nada do §6/§7.
+
+O site foi ao ar **com a #12 ainda em aberto** (chave OpenAI legada de 2023 exposta
+no histórico público): Pages não dependeu daquele P0 como este documento supunha.
+A #12 segue aberta e agora é **mais** urgente, porque o repo está com o site no ar.
 
 ## §3 — Labels (taxonomia oficial)
 


### PR DESCRIPTION
## Contexto
`docs/fleet/HANDBOOK.md` §2 → **Produção** afirmava que o GitHub Pages "ainda não está habilitado" e que "merge na main NÃO derruba produção". **Isso não é mais verdade** e instrui a frota a operar com rigor mais baixo do que a realidade exige — um defeito de segurança operacional, não de redação.

Evidência colhida nesta rodada:
- `gh api repos/caioross/NostalgiaGPT/pages` → `source: { branch: "main", path: "/" }`, servindo LIVE
- Site no ar: <https://caioross.github.io/NostalgiaGPT/>
- `index.html` na `main` é a versão 2026 (title com SEO, carrega `js/personalities.js`)

## O que mudou e por quê
Reescreve **apenas** o bloco §2 → Produção (linhas 49-52) para refletir o estado real:
- Pages **habilitado**, servindo `main` na raiz → **`main` = produção**, todo merge vai ao ar.
- Rigor máximo explícito: **main quebrada = site fora do ar** (não só a vitrine); PR Doctor lê o diff inteiro; gate verde obrigatório — **sem enfraquecer nada do §6/§7**.
- Remove a dependência invertida: o texto sugeria que Pages dependia da #12; na prática o site já está no ar **com a #12 ainda aberta** (chave legada de 2023 no histórico público), que agora é **mais** urgente.

Diff cirúrgico: **1 arquivo, 9 inserções / 4 remoções**, nenhuma outra seção alterada (HANDBOOK §8.4).

## Resultado do gate (real)
`node scripts/gate.mjs` → **GATE VERDE — 19/19 checagens passaram.** (mudança é só markdown; o gate não é afetado.)

## Riscos
Baixo — documentação. O efeito é **subir** o rigor da frota, não baixar. Nenhuma mudança de código, do gate ou de outras seções.

## Quórum
Mudança no HANDBOOK exige revisão adversarial das 3 lentes (HANDBOOK §7.2).
Solicito quórum (HANDBOOK §7)

Closes #28