### PR TITLE
docs: registra origem, versao e licenca MIT do Brusher em ATTRIBUTION.md

### DIFF
--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -1,0 +1,93 @@
+# 📜 Créditos e licenças de terceiros
+
+Este arquivo registra a origem, a versão e a licença de todo código de terceiros
+**redistribuído** neste repositório, além das dependências carregadas por CDN.
+
+---
+
+## Brusher — `brusher-demo.min.js` · `brusher-demo.min.css`
+
+Responsável pelo efeito de fundo esfumaçado revelado pelo movimento do mouse
+(o "efeito Brusher" da home — ver `css/styles.css:52` e `index.html:88`).
+
+| Campo | Valor |
+|---|---|
+| **Projeto** | Brusher — *Create beautiful webpage backgrounds* |
+| **Autor** | Kamran Ahmed |
+| **Repositório** | <https://github.com/nilbuild/brusher> (antes `kamranahmedse/brusher`) |
+| **Pacote npm** | [`brusher`](https://www.npmjs.com/package/brusher) |
+| **Versão** | `0.1.4` (versão do `package.json` do upstream no commit do build) |
+| **Origem exata dos arquivos** | `dist/demo/` do upstream, commit `931f14e` (2019-06-14, *"Update demo"*) |
+| **Licença** | MIT |
+
+### Verificação de integridade
+
+Os dois arquivos são **idênticos** aos do upstream: os hashes de blob Git abaixo
+conferem com os retornados pela API do GitHub para `dist/demo/`.
+
+```
+891fda41c508c9e18ad22b193ada970b2e4eaf8f  brusher-demo.min.js   (169.408 bytes)
+01043a6031ab3369181930fb5bb0c09a79372d0c  brusher-demo.min.css  (  2.956 bytes)
+```
+
+Tamanhos são os do blob (fim de linha LF); em checkout no Windows o arquivo em
+disco pode ficar maior por causa da conversão para CRLF — o blob, que é o que o
+hash cobre, continua idêntico.
+
+Para reconferir localmente:
+
+```bash
+git hash-object brusher-demo.min.js brusher-demo.min.css
+```
+
+> **Nota técnica:** trata-se do bundle do *demo* do projeto (webpack, `library: Brusher`),
+> não do `dist/brusher.min.js` enxuto — daí o nome e o tamanho. O bundle embute
+> [core-js](https://github.com/zloirock/core-js) (polyfills, também MIT).
+
+### Texto da licença (obrigatório preservar)
+
+```
+The MIT License (MIT)
+
+Copyright (c) 2018 Kamran Ahmed
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+MIT permite uso, modificação e redistribuição — inclusive comercial — desde que o
+aviso de copyright e o texto acima sejam preservados. Este arquivo cumpre esse dever.
+
+---
+
+## Dependências carregadas por CDN (não redistribuídas)
+
+Não há cópia destes arquivos no repositório; são referenciados em `index.html`.
+
+| Recurso | Versão | Origem | Licença |
+|---|---|---|---|
+| jQuery | 2.2.4 | cdnjs (`index.html:244`) | MIT |
+| Google Fonts — Cinzel, Lora | — | fonts.googleapis.com (`index.html:80`) | SIL Open Font License 1.1 |
+
+---
+
+## Conteúdo próprio
+
+O código do NostalgiaGPT (HTML, `css/styles.css`, `js/*.js`) é distribuído sob a
+[licença MIT](LICENSE) do projeto. As fotos em `persons/` retratam figuras
+históricas de domínio público.

--- a/README.md
+++ b/README.md
@@ -229,6 +229,10 @@ git commit -m "feat: adiciona personalidade X"
 
 Distribuído sob a [licença MIT](LICENSE). Use, modifique e distribua à vontade.
 
+Código de terceiros redistribuído aqui — como o **Brusher** (MIT, de Kamran Ahmed),
+responsável pelo efeito de fundo esfumaçado — está creditado em
+[ATTRIBUTION.md](ATTRIBUTION.md).
+
 ---
 
 <div align="center">
@@ -331,6 +335,10 @@ NostalgiaGPT/
 ### 📄 License
 
 Distributed under the [MIT License](LICENSE). Use, modify, and distribute freely.
+
+Third-party code redistributed here — such as **Brusher** (MIT, by Kamran Ahmed),
+which powers the blurred background effect — is credited in
+[ATTRIBUTION.md](ATTRIBUTION.md).
 
 ---
 


### PR DESCRIPTION
## Contexto

`brusher-demo.min.js` (169 KB) e `brusher-demo.min.css` estão na raiz e em uso
(`index.html:88`; `css/styles.css:52`), mas sem qualquer registro de origem,
versão ou licença — risco de supply chain e bloqueio para redistribuição (#9).

## Procedência confirmada (com evidência)

O bundle é UMD com `library: Brusher` e carrega source maps inline. Decodificando-os,
os `sources` apontam para `webpack://Brusher/./src/index.js` e `./demo/scripts/demo.js`
— ou seja, é o build do **demo** da lib Brusher, não o `dist/brusher.min.js` enxuto.

- **Projeto:** [nilbuild/brusher](https://github.com/nilbuild/brusher) (antes `kamranahmedse/brusher`), autor Kamran Ahmed
- **Licença:** MIT (`Copyright (c) 2018 Kamran Ahmed`) — compatível com redistribuição
- **Versão:** `0.1.4` (`package.json` do upstream)
- **Origem exata:** `dist/demo/`, commit `931f14e` (2019-06-14)

Prova de integridade — os hashes de blob Git dos nossos arquivos batem **exatamente**
com os que a API do GitHub retorna para `dist/demo/` do upstream:

```
891fda41c508c9e18ad22b193ada970b2e4eaf8f  brusher-demo.min.js
01043a6031ab3369181930fb5bb0c09a79372d0c  brusher-demo.min.css
```

Nenhuma modificação local, portanto — o código vendored é o upstream intacto.

## O que mudou

- **`ATTRIBUTION.md` (novo):** origem, versão, commit, hashes de verificação, nota sobre
  o core-js embutido no bundle e o **texto integral da licença MIT** (a MIT exige
  preservar o aviso de copyright — sem isso a redistribuição estava tecnicamente
  irregular). Inclui também as dependências de CDN não redistribuídas (jQuery 2.2.4, Google Fonts).
- **`README.md`:** uma linha na seção de licença de cada idioma (PT e EN) apontando para o arquivo.

Só documentação. Nenhum arquivo de código, nenhum asset e nenhum byte do Brusher foi tocado.

## Gate

```
GATE VERDE — 19/19 checagens passaram.
```

## Riscos

Nulo em runtime — o diff é 100% Markdown.

Observação fora do escopo, para registro: `brusher-demo.min.css` está no repo mas
**não é referenciado** pelo `index.html` (só o `.js` é, na linha 88). Não removi
nada aqui — órfãos de assets são tema da #33.

Closes #9