### PR TITLE
fix(ui): modal da gôndola rola em viewport baixa — Confirmar deixa de ficar inacessível

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -533,9 +533,15 @@ button { font-family: var(--font-body); cursor: pointer; }
   background: linear-gradient(180deg, var(--bg-card) 0%, var(--bg-surface) 100%);
   border: 1px solid var(--border-strong); border-radius: 18px;
   box-shadow: 0 50px 120px rgba(0,0,0,0.8), 0 0 80px rgba(201,168,76,0.06);
-  padding: 2rem 1.5rem 1.5rem; overflow: hidden;
+  padding: 2rem 1.5rem 1.5rem;
+  max-height: calc(100vh - 2.5rem); max-height: calc(100dvh - 2.5rem);
+  overflow-x: hidden; overflow-y: auto;
+  scrollbar-width: thin; scrollbar-color: var(--gold-dim) transparent;
   animation: modalIn 0.45s cubic-bezier(0.22, 1, 0.36, 1) forwards;
 }
+.picker-modal::-webkit-scrollbar { width: 4px; }
+.picker-modal::-webkit-scrollbar-track { background: transparent; }
+.picker-modal::-webkit-scrollbar-thumb { background: var(--gold-dim); border-radius: 2px; }
 .picker-close {
   position: absolute; top: 1rem; right: 1rem; z-index: 5;
   width: 38px; height: 38px; display: flex; align-items: center; justify-content: center;


### PR DESCRIPTION
## Contexto

`.picker-modal` não tinha `max-height` e usava `overflow: hidden`. Com o `.picker-overlay` centralizando via `align-items: center`, um modal mais alto que a viewport transbordava para os **dois** lados: sumiam o `.picker-title` + `#picker-search` no topo e o `#picker-confirm` no rodapé, sem nenhuma forma de rolar até eles. O usuário ficava preso (só Esc ou clique no backdrop) e não conseguia confirmar a seleção.

Fecha #40.

## O que mudou (só CSS, 1 regra + 3 linhas de scrollbar)

`css/styles.css` — `.picker-modal`:

- `max-height: calc(100vh - 2.5rem)` com fallback progressivo para `calc(100dvh - 2.5rem)` — `2.5rem` é exatamente o `padding: 1.25rem` do `.picker-overlay` nos dois lados. `dvh` importa em mobile, onde `100vh` inclui a barra de URL retrátil e ainda cortaria o rodapé.
- `overflow: hidden` → `overflow-x: hidden; overflow-y: auto` — o eixo X segue clipado como hoje (as setas `.gondola-nav` em `left/right: -4px` continuam contidas); o eixo Y passa a rolar quando — e só quando — o conteúdo excede a altura disponível.
- Scrollbar no padrão de `.messages-content`: `scrollbar-width: thin` + `scrollbar-color: var(--gold-dim) transparent` e os três `::-webkit-scrollbar*` equivalentes.

Optei por **não** mexer no `.picker-overlay`: como o modal nunca mais excede a viewport, um `overflow-y` no overlay seria código morto e mexeria na centralização (o truque `margin: auto` para não cortar o topo em Flexbox), que o AC exige preservar intacta.

## Por que o layout em viewport alta não muda

Em 1440×900 a altura natural do modal (~600–700px) fica abaixo de `calc(100vh - 2.5rem)` = 860px, então o `max-height` nunca entra em ação e `overflow-y: auto` não renderiza scrollbar. Nada de centralização, tema ou animação foi tocado.

## Riscos

- Baixo. Nenhum JS, nenhum seletor novo, nenhuma dependência.
- Coverflow: o `perspective` fica em `.gondola-viewport` e o `transform-style: preserve-3d` em `.gondola-track` — ambos **abaixo** do `.picker-modal`, então o novo contexto de rolagem do ancestral não interfere no `translateZ` dos cards. O `overflow-x: auto` do track é outro eixo, em outro elemento: sem conflito.
- `dvh` não suportado (navegadores antigos) → cai no `100vh`, que já resolve o bug em desktop.
- Efeito Brusher, tema dark vintage e zero-build intactos (HANDBOOK §2). Classificação: §7.3 normal (polish de CSS).

## Gate

```
node scripts/gate.mjs
GATE VERDE — 19/19 checagens passaram.
```

## Teste manual sugerido (não pude executar nesta rodada)

O browser headless da rodada não subiu (timeout ao abrir a página), então a verificação foi analítica sobre o CSS. Vale confirmar no navegador:

1. Abrir a página e redimensionar para **900×600** e depois **740×360**.
2. Clicar em "Trocar de personagem".
3. Conferir que `.picker-title`, `#picker-search` e `#picker-confirm` são alcançáveis por scroll **e** por Tab, sem sair do modal.
4. Arrastar/rolar o coverflow horizontalmente e confirmar que os cards ainda giram em 3D.
5. Em 1440×900, confirmar que **não** aparece scrollbar e a centralização é a de sempre.
