### PR TITLE
feat(ui): restaura o hero em index.html com o `<h1>` que faltava (#45)

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,6 +87,44 @@
   <!-- ═══ Efeito de fundo "Brusher" (esfumaçado / revelar) ═══ -->
   <script src="brusher-demo.min.js"></script>
 
+  <!-- ═══════════════════ HERO ═══════════════════ -->
+  <section class="hero" aria-label="Apresentação">
+    <div class="hero-content">
+      <p class="hero-eyebrow">Converse com a História</p>
+      <h1 class="hero-title"><span class="title-nostalgia">Nostalgia</span><span class="title-gpt">GPT</span></h1>
+      <p class="hero-subtitle">Dê voz a quem moldou o mundo: converse em primeira pessoa com mais de 40 personalidades históricas, da ciência à arte, da filosofia à música.</p>
+      <div class="hero-figures-cloud">
+        <span>Albert Einstein</span>
+        <span>Leonardo da Vinci</span>
+        <span>Cleópatra</span>
+        <span>Nikola Tesla</span>
+        <span>Shakespeare</span>
+        <span>Mahatma Gandhi</span>
+        <span>Ludwig van Beethoven</span>
+        <span>Platão</span>
+        <span>Ayrton Senna</span>
+      </div>
+      <div class="hero-actions">
+        <a class="hero-cta" href="#chat">
+          Começar a conversar
+          <svg class="cta-arrow" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <line x1="12" y1="5" x2="12" y2="19"></line><polyline points="19 12 12 19 5 12"></polyline>
+          </svg>
+        </a>
+        <button type="button" class="hero-cta-ghost" data-open-picker aria-haspopup="dialog" aria-label="Escolher personagem">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <rect x="3" y="3" width="7" height="7"></rect><rect x="14" y="3" width="7" height="7"></rect>
+            <rect x="14" y="14" width="7" height="7"></rect><rect x="3" y="14" width="7" height="7"></rect>
+          </svg>
+          Escolher personagem
+        </button>
+      </div>
+    </div>
+    <div class="hero-scroll-hint" aria-hidden="true">
+      <div class="scroll-line"></div>
+    </div>
+  </section>
+
   <!-- ═══════════════════ CHAT ═══════════════════ -->
   <section class="chat-section" id="chat" aria-label="Interface de chat">
     <div class="chat-section-bg" aria-hidden="true"></div>


### PR DESCRIPTION
## Contexto

`index.html` começava direto na `<section class="chat-section">`: a página LIVE **não tinha nenhum `<h1>`** (só o `<h2>` do modal `hidden`) e o CSS completo do hero estava órfão em `css/styles.css:138-221`. Esta é a **fatia 1 de #44** — a que sozinha resolve um critério do épico.

## O que mudou (e por quê)

- Adiciona `<section class="hero">` **antes** da `chat-section` (`index.html:91`), reaproveitando integralmente o CSS órfão — **nenhuma regra nova em `css/styles.css`**.
- Entrega o **único `<h1>`** da página (`.hero-title`) com os dois spans `.title-nostalgia` / `.title-gpt`, nome do produto em **texto real e rastreável**.
- Eyebrow, subtítulo, nuvem de 9 figuras e os dois CTAs, na ordem dos delays `fadeUp` (0.2s → 1s).
- CTA principal (`.hero-cta`) → `#chat`; CTA ghost (`.hero-cta-ghost`) abre a gôndola via `data-open-picker` (mesmo hook do `#open-picker`, ligado por delegação em `mainJs.js:521`).
- Figuras da nuvem conferidas uma a uma contra `js/personalities.js` (Einstein, da Vinci, Cleópatra, Tesla, Shakespeare, Gandhi, Beethoven, Platão, Ayrton Senna) — nenhuma inventada.
- SVGs dos CTAs com `aria-hidden="true"`, como os já usados na página.

## Áreas sagradas (HANDBOOK §2) — intactas

Brusher (`body.homepage`, `brusher-demo.min.js`, `images/homepage*.jpg`), tema dark vintage e zero-build **não foram tocados**. `js/personalities.js` e `js/mainJs.js` também não. Diff: **+38 linhas, só markup em `index.html`**.

## Gate

`node scripts/gate.mjs` → **GATE VERDE — 19/19**. `grep -c '<h1' index.html` = **1**.

## Teste manual sugerido

Abrir `index.html` no browser: (1) o hero ocupa a primeira viewport com a fumaça do Brusher visível através do fundo transparente; (2) título com shimmer dourado no `:hover`; (3) "Começar a conversar" rola até o chat; (4) "Escolher personagem" abre a gôndola; (5) chat e gôndola sem regressão.

## Quórum

Mudança estrutural em `index.html` (SEO/heading) → **Solicito quórum (HANDBOOK §7)**

Closes #45 · Refs #44