### PR TITLE
fix(a11y): anel de foco dourado nos cards da gôndola (#15)

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -617,6 +617,8 @@ button { font-family: var(--font-body); cursor: pointer; }
   border-color: var(--gold);
   box-shadow: 0 24px 60px rgba(0,0,0,0.6), 0 0 0 1px var(--gold), 0 0 50px rgba(201,168,76,0.18);
 }
+/* offset maior que o da galeria: separa o anel da borda dourada do card ativo */
+.gondola-card:focus-visible { outline: 2px solid var(--gold); outline-offset: 3px; }
 .gcard-avatar { width: 92px; height: 92px; margin-bottom: 0.3rem; position: relative; }
 .gcard-avatar .avatar-img,
 .gcard-avatar .monogram {


### PR DESCRIPTION
## Contexto

Os cards da gôndola são interativos por teclado (`js/mainJs.js:358-359` — `tabIndex = 0` + `role="button"`, Enter tratado em `js/mainJs.js:372-374`), mas não existia nenhuma regra `:focus`/`:focus-visible` para `.gondola-card`. O foco por teclado ficava praticamente invisível sobre o fundo dark vintage, inconsistente com o padrão dourado já usado na galeria (`css/styles.css:435` — `.p-card:focus-visible`).

## O que mudou e por quê

Uma única regra em `css/styles.css`, reaproveitando o token `--gold`:

```css
.gondola-card:focus-visible { outline: 2px solid var(--gold); outline-offset: 3px; }
```

- **`outline` e não `box-shadow`**: medi a geometria no browser — a scrollport do `.gondola-track` é o padding box, e o track tem `padding: 1.5rem … 2rem` (`css/styles.css:600`). O anel (offset 3px + 2px de espessura = 5px) cabe com folga de **24,1px no topo e 31,9px na base**, então o `overflow-y: hidden` (`css/styles.css:598`) **não** o corta. A alternativa `box-shadow` sugerida na issue não foi necessária.
- **`outline-offset: 3px`** (maior que os 2px da galeria): afasta o anel da borda dourada rente do card `.is-active` (`css/styles.css:616-619`), mantendo foco e estado ativo distinguíveis.
- O `outline` acompanha sozinho o `border-radius: 16px` do card — sem redeclarar nada.
- Nada de `opacity`/`z-index`/layout: o coverflow (`js/mainJs.js:400-421`) fica intocado.

## Teste feito (browser real, servidor estático local)

Naveguei com Tab de verdade até os cards e li os valores computados:

| Card focado | `:focus-visible` | `outline` computado | opacidade | anel clipado? |
|---|---|---|---|---|
| Einstein (central, `.is-active`) | `true` | `2px solid rgb(201,168,76)` | 0.99 | não (folga 24,1 / 31,9) |
| Newton (vizinho) | `true` | `2px solid rgb(201,168,76)` | 0.70 | não (folga 40,4 / 48,1) |

`rgb(201,168,76)` é exatamente o `--gold`. Foco por mouse não dispara a regra (`:focus-visible`), como pedido.

## Achado fora do escopo (⚠️ vale issue própria)

Durante o teste apareceu um defeito de a11y **pré-existente e independente desta mudança**: **tabular não rola a gôndola**. Ao chegar no 4º card (Darwin), o `scrollLeft` do track permanece `0` mesmo após 2s, e o card focado fica **inteiramente fora da scrollport** (311,7px além da borda direita, opacidade 0.3). Ou seja: para cards distantes do centro, o anel existe e está correto, mas o próprio card está fora da vista.

Corrigir isso exige JS (centralizar o card no evento `focus`, como o clique já faz via `centerCard`, `js/mainJs.js:433`) — fora do escopo declarado na #15 ("só estilo de foco", "diff mínimo, só `css/styles.css`", "nenhuma mudança no layout/coverflow"). Não toquei nisso para não entregar fora de escopo; deixo registrado para o Curador abrir issue dedicada. Relacionado ao arco de foco por teclado das #16/#30.

`Closes #15` porque o escopo definido pela issue — a regra de foco em `css/styles.css`, coerente com a galeria — está completo e verificado. Se preferir tratar o item de scroll como parte da #15, é só trocar para `Refs #15` no merge.

## Gate

```
node scripts/gate.mjs
GATE VERDE — 19/19 checagens passaram.
```

## Riscos

Baixos. Uma regra CSS puramente aditiva, escopo `:focus-visible`, sem `!important`, sem mudança de layout. Brusher, tema dark vintage e zero-build intactos (HANDBOOK §2). Classificação: HANDBOOK §7.3 (normal — polish de a11y/CSS).

Closes #15