### PR TITLE
fix(chat): só empilha o turno `user` quando a resposta chega (#53)

### DIFF
--- a/js/mainJs.js
+++ b/js/mainJs.js
@@ -186,10 +186,14 @@
     input.value = ''; input.style.height = 'auto';
     appendUserMessage(msgText);
     showTyping();
-    conversation.push({ role: 'user', content: msgText });
+    /* O turno do usuário só entra em `conversation` quando a resposta chega (par
+       user+assistant no `then`). Assim uma falha não deixa turno órfão no histórico
+       nem envenena a janela slice(-10) das tentativas seguintes. A requisição atual
+       usa `concat` (cópia) para já incluir o turno sem mutar o estado. */
+    var userTurn = { role: 'user', content: msgText };
 
     var messages = [{ role: 'system', content: buildSystemPrompt(currentPerson) }]
-      .concat(conversation.slice(-10));
+      .concat(conversation.concat([userTurn]).slice(-10));
 
     /* Timeout via AbortController (vanilla; sem dependência). Falha silenciosa
        de rede vira AbortError após OPENAI_TIMEOUT ms. O controller vive em `pending`
@@ -238,7 +242,7 @@
         var text = (data.choices && data.choices[0] && data.choices[0].message &&
           data.choices[0].message.content) ? data.choices[0].message.content.trim() : '';
         if (!text) text = '...';
-        conversation.push({ role: 'assistant', content: text });
+        conversation.push(userTurn, { role: 'assistant', content: text });
         appendAIMessage(text);
       })
       .catch(function (err) {


### PR DESCRIPTION
## Contexto

`js/mainJs.js` empilhava o turno `user` em `conversation` **antes** do `fetch` (linha 189). Quando a chamada falhava (offline, timeout, 401, 429, 5xx), o `catch` mostrava a mensagem amigável mas não desfazia o `push` — o turno ficava órfão para sempre (só `applyPerson()` zera `conversation`), envenenando a janela `conversation.slice(-10)` de todas as requisições seguintes.

## O que mudou (2 pontos, diff mínimo)

1. O turno vira uma variável local `userTurn` — não é mais empilhado no envio. A requisição atual monta `messages` com `conversation.concat([userTurn]).slice(-10)`: **cópia**, sem mutar o estado, janela de 10 turnos idêntica à de antes.
2. No `then` de sucesso, o par entra junto e na ordem: `conversation.push(userTurn, { role: 'assistant', content: text })`.

Nenhuma mudança no bloco `fetch`, no `catch`, no lock `pending`, no timeout ou no `chatErrorMessage`.

## Acceptance criteria

- [x] Falha em qualquer ramo de `chatErrorMessage` → `conversation` fica exatamente como antes do envio (o turno nunca chegou a entrar; o `catch` não precisou de lógica de reversão).
- [x] Sucesso continua empilhando `user` + `assistant` na ordem correta.
- [x] `req.cancelled === true` (troca de personagem) retorna antes do `push` em ambos os ramos — nada é duplicado nem "ressuscitado".
- [x] Cenário do "Como reproduzir": na etapa 4 a janela vai como `[system, user:"<mensagem real>"]`.
- [x] A mensagem de erro segue só no DOM (`appendAIMessage`), fora de `conversation`.
- [x] Gate verde.

## Gate (resultado real, no worktree)

```
GATE VERDE — 19/19 checagens passaram.
```

## Teste manual sugerido (muda comportamento do chat)

1. Abrir o chat, escolher uma personalidade, DevTools → Network → **Offline**.
2. Enviar `"Olá"` 4×: aparece o erro 📡 a cada tentativa.
3. Voltar **Online**, enviar uma mensagem real e inspecionar o `body` da requisição — deve conter apenas `[system, user:"<mensagem real>"]`.
4. Confirmar o caminho feliz: 2 mensagens seguidas com resposta; a 2ª requisição deve levar `[system, user, assistant, user]`.
5. Trocar de personagem no meio de uma resposta em voo — nada deve aparecer nem reaparecer no chat novo.

## Riscos

Baixos e localizados. O comportamento visível do chat é idêntico no caminho de sucesso; a diferença só aparece após uma falha. `userTurn` é capturado pelo closure do `then` — o lock `pending` já impede envios concorrentes, então não há corrida de dois `userTurn` para o mesmo `conversation`.

Toca o fluxo do chat/chamada OpenAI em `mainJs.js` → **Solicito quórum (HANDBOOK §7)**

Closes #53
