### PR TITLE
fix(chat): demo sem chave responde ao visitante em vez de 401 (#54)

### DIFF
--- a/js/mainJs.js
+++ b/js/mainJs.js
@@ -176,20 +176,23 @@
     return '📡 Não consegui falar com a OpenAI. Verifique sua conexão com a internet e tente novamente.';
   }
 
-  /* A vitrine pública é servida com o placeholder no lugar da chave (HANDBOOK §6),
-     então toda chamada à OpenAI só poderia voltar 401. Detecta essa condição para
-     responder ao visitante sem tocar a rede. */
+  /* O fonte versiona o placeholder no lugar da chave (HANDBOOK §6), então toda
+     chamada à OpenAI só poderia voltar 401 — tanto na vitrine pública quanto em
+     quem abriu o index.html antes de configurar a chave. Detecta essa condição
+     para responder sem tocar a rede. */
   function isDemoWithoutKey() {
     return !OPENAI_KEY || OPENAI_KEY === 'SUA_CHAVE_OPENAI_AQUI';
   }
-  /* Mensagem para o VISITANTE da demo — sem jargão de código; quem roda local com
-     chave própria nunca vê esta mensagem (um 401 real cai em chatErrorMessage). */
+  /* Mensagem sem jargão de código, e agnóstica de onde a página está rodando: o
+     código não tem como saber se é a vitrine ou uma cópia local, então o texto não
+     afirma nem uma coisa nem outra — só diz o que falta e onde está o passo a passo.
+     Quem já configurou a chave nunca vê isto (401 real cai em chatErrorMessage). */
   function demoWithoutKeyMessage() {
-    return '🕰️ Esta é a vitrine pública do NostalgiaGPT: uma demonstração que não ' +
-      'acompanha chave da OpenAI, e por isso minha voz não pode atravessar até aqui. ' +
-      'Para conversar comigo de verdade, rode o projeto na sua máquina com a sua ' +
-      'própria chave — o passo a passo está na seção "Configurar a API da OpenAI" do ' +
-      'README, em github.com/caioross/NostalgiaGPT.';
+    return '🕰️ Esta demonstração do NostalgiaGPT está sem chave da OpenAI ' +
+      'configurada, e por isso minha voz não pode atravessar até aqui. Para ' +
+      'conversar comigo de verdade é preciso rodar o projeto com uma chave própria ' +
+      '— o passo a passo está na seção "Configurar a API da OpenAI" do README, em ' +
+      'github.com/caioross/NostalgiaGPT.';
   }
 
   window.insertMessage = function () {

--- a/js/mainJs.js
+++ b/js/mainJs.js
@@ -176,6 +176,22 @@
     return '📡 Não consegui falar com a OpenAI. Verifique sua conexão com a internet e tente novamente.';
   }
 
+  /* A vitrine pública é servida com o placeholder no lugar da chave (HANDBOOK §6),
+     então toda chamada à OpenAI só poderia voltar 401. Detecta essa condição para
+     responder ao visitante sem tocar a rede. */
+  function isDemoWithoutKey() {
+    return !OPENAI_KEY || OPENAI_KEY === 'SUA_CHAVE_OPENAI_AQUI';
+  }
+  /* Mensagem para o VISITANTE da demo — sem jargão de código; quem roda local com
+     chave própria nunca vê esta mensagem (um 401 real cai em chatErrorMessage). */
+  function demoWithoutKeyMessage() {
+    return '🕰️ Esta é a vitrine pública do NostalgiaGPT: uma demonstração que não ' +
+      'acompanha chave da OpenAI, e por isso minha voz não pode atravessar até aqui. ' +
+      'Para conversar comigo de verdade, rode o projeto na sua máquina com a sua ' +
+      'própria chave — o passo a passo está na seção "Configurar a API da OpenAI" do ' +
+      'README, em github.com/caioross/NostalgiaGPT.';
+  }
+
   window.insertMessage = function () {
     var input = document.getElementById('chat-input');
     if (!input || !currentPerson) return;
@@ -185,6 +201,12 @@
 
     input.value = ''; input.style.height = 'auto';
     appendUserMessage(msgText);
+
+    /* Caminho curto da demo sem chave: responde e encerra ANTES de showTyping(),
+       do fetch e do lock — nada fica em voo, nada fica preso, `conversation`
+       segue intacta (nenhum turno órfão para a janela slice(-10)). */
+    if (isDemoWithoutKey()) { appendAIMessage(demoWithoutKeyMessage()); return; }
+
     showTyping();
     /* O turno do usuário só entra em `conversation` quando a resposta chega (par
        user+assistant no `then`). Assim uma falha não deixa turno órfão no histórico


### PR DESCRIPTION
## Contexto

O site está LIVE e, por regra do gate (HANDBOOK §6), `js/mainJs.js` versiona `OPENAI_KEY` como placeholder. Consequência: **toda** mensagem de um visitante disparava um `POST` para `api.openai.com` com `Authorization: Bearer SUA_CHAVE_OPENAI_AQUI`, voltava 401 e caía na mensagem de erro escrita para quem roda o projeto localmente — "Configure a constante OPENAI_KEY em js/mainJs.js e recarregue a página".

## O que mudou (diff: +22 linhas, só `js/mainJs.js`)

1. `isDemoWithoutKey()` — compara `OPENAI_KEY` com o literal placeholder (também trata valor vazio). Não é constante de configuração nova: é uma checagem interna ao lado de `chatErrorMessage()`, e a atribuição em `js/mainJs.js:13` segue intocada.
2. `demoWithoutKeyMessage()` — texto em PT-BR no tom vintage do produto, dirigido ao **visitante**: explica que a vitrine pública não acompanha chave e aponta o caminho real (rodar local com a própria chave; seção **"Configurar a API da OpenAI"** do `README.md:120`, em `github.com/caioross/NostalgiaGPT`). Sem jargão de `var`/constante/arquivo.
3. Caminho curto em `insertMessage()`, logo após ecoar a mensagem do visitante e **antes** de `showTyping()`: responde e retorna. Nenhum `fetch`, nenhum `typing-row`, nenhum `setChatBusy(true)`, nenhum turno órfão em `conversation` (a janela `slice(-10)` fica intacta).

Todos os pontos de envio passam por `window.insertMessage` — botão (`index.html:223`), Enter (`js/mainJs.js:576`) e clique em starter (`js/mainJs.js:94`) —, então a cobertura é completa.

## Acceptance criteria

- [x] Com o placeholder, `insertMessage()` não dispara requisição — o único `fetch` do projeto (`js/mainJs.js:235`) fica depois do `return`.
- [x] Mensagem ao visitante em PT-BR, tom vintage, sem jargão de código.
- [x] Caminho citado existe: seção "🔑 Configurar a API da OpenAI" do README.
- [x] Com chave real, comportamento idêntico ao de hoje; 401 legítimo continua em `chatErrorMessage()` (inalterada).
- [x] Sem nova constante de configuração; `OPENAI_KEY` continua sendo o placeholder literal no fonte.
- [x] `typing` e lock não ficam presos — nunca são acionados nesse caminho.
- [x] Gate verde.

## Gate (resultado real, executado no worktree)

```
node scripts/gate.mjs
GATE VERDE — 19/19 checagens passaram.
```

Inclui `[OK] OPENAI_KEY = placeholder (correto para versionar)` e `[OK] nenhum segredo real em arquivos rastreados`.

## Teste manual sugerido (revisor)

1. Abrir `index.html` (fonte como está, com placeholder), escolher uma personalidade e enviar uma mensagem.
2. Aba **Network**: zero requisições para `api.openai.com`. No chat: a mensagem do visitante aparece e a resposta é o aviso da demo. O campo de texto continua habilitado e não há bolha de "digitando" presa.
3. Substituir localmente `OPENAI_KEY` por uma chave real (sem commitar): o chat volta a responder normalmente.

## Riscos

- Baixo e localizado. A única mudança de comportamento ocorre quando `OPENAI_KEY` é o placeholder — condição em que hoje só existe 401.
- Fora de escopo, como a issue determina: nenhum campo para o visitante colar chave, nenhum `localStorage` de chave, nenhum proxy/backend (núcleo §7.1) e nada relacionado ao P0 #12.

Toca o fluxo do chat em `mainJs.js` → **Solicito quórum (HANDBOOK §7)**

Closes #54
