### PR TITLE
feat(ui): restaura a seção da galeria em index.html (fatia 2 de #44)

### DIFF
--- a/index.html
+++ b/index.html
@@ -234,6 +234,32 @@
     </div>
   </section>
 
+  <!-- ═══════════════════ GALERIA ═══════════════════ -->
+  <section class="gallery-section" id="galeria" aria-label="Galeria de personalidades">
+    <div class="gallery-container">
+      <div class="section-header">
+        <h2 class="section-title">A Galeria das Lendas</h2>
+        <p class="section-subtitle">
+          Mais de quarenta vozes reunidas em seis salas — Ciência &amp; Tecnologia, Arte &amp; Literatura,
+          Filosofia &amp; Fé, Líderes &amp; Política, Música e Esporte &amp; Lendas. Escolha um nome e a conversa começa.
+        </p>
+      </div>
+
+      <!-- Grupos, contagens e cards são gerados por buildGallery() (js/mainJs.js) -->
+      <div id="gallery"></div>
+
+      <div class="gallery-cta-wrap">
+        <button type="button" class="ghost-btn" data-open-picker aria-haspopup="dialog" aria-label="Abrir a Gôndola de Lendas">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <rect x="3" y="3" width="7" height="7"></rect><rect x="14" y="3" width="7" height="7"></rect>
+            <rect x="14" y="14" width="7" height="7"></rect><rect x="3" y="14" width="7" height="7"></rect>
+          </svg>
+          Abrir a Gôndola
+        </button>
+      </div>
+    </div>
+  </section>
+
   <!-- ═══════════════════ MODAL: GÔNDOLA ═══════════════════ -->
   <div class="picker-overlay" id="picker" hidden>
     <div class="picker-backdrop" data-close-picker></div>


### PR DESCRIPTION
## Contexto

Fatia 2 do épico #44 (a fatia 1 — hero — saiu em #46). O CSS da galeria (`css/styles.css:391-403` e `:456`) e o JS (`buildGallery()`, `js/mainJs.js:316-345`, chamado em `js/mainJs.js:541`) já existiam e estavam vivos, mas **o markup do container não existia**: `buildGallery()` morria no `var g = document.getElementById('gallery'); if (!g) return;` e os 47 nomes de `js/personalities.js` nunca apareciam em conteúdo visível da landing.

## O que mudou e por quê

Um único bloco novo em `index.html`, inserido **depois** de `</section>` do `#chat` e **antes** do modal `.picker-overlay` — a ordem visual pretendida (hero → chat → galeria), já que `.gallery-section` tem `border-top`:

- `<section class="gallery-section" id="galeria">` › `.gallery-container` › `.section-header` com `<h2 class="section-title">` e `.section-subtitle`;
- `<div id="gallery"></div>` — os 6 `.gallery-group`, os `.group-head` (ícone/label/contagem) e os `.p-card` continuam sendo gerados por `buildGallery()`, nada disso vai para o HTML;
- `.gallery-cta-wrap` com um `.ghost-btn` que **reaproveita o handler existente** `[data-open-picker]` (`js/mainJs.js:550`) — sem JS novo.

**Zero CSS novo e zero JS novo: o diff toca apenas `index.html` (+26 linhas).** O `id="galeria"` foi incluído para dar âncora estável ao rodapé da fatia 3 (#60).

## Resultado real do gate

```
$ node scripts/gate.mjs
GATE VERDE — 19/19 checagens passaram.
```

Validação complementar (simulando o agrupamento de `buildGallery()` sobre `NostalgiaData`, e conferindo o markup):

```
Ciência & Tecnologia — 7 · Arte & Literatura — 10 · Filosofia & Fé — 7
Líderes & Política — 14 · Música — 5 · Esporte & Lendas — 4
TOTAL grupos=6 pessoas=47
id="gallery" no HTML: 1 · dentro de .gallery-container: true
ordem hero < chat < galeria < modal: true
```

## Teste manual sugerido (mudança visual)

1. Abrir `index.html` no browser: abaixo do chat deve surgir "A Galeria das Lendas" com **6 grupos** e **47 cards** (contagens acima), sobre o fundo `rgba(7,7,13,0.62)` com `border-top` dourado-escuro.
2. Clicar num `.p-card` → troca a personalidade no header do chat e rola até `#chat` (`applyPerson(p, true)`).
3. Clicar em "Abrir a Gôndola" → abre o modal (mesmo comportamento do CTA do hero).
4. Brusher intacto: fundo esfumaçado revela ao passar o mouse no hero.

> Não consegui rodar o preview no browser nesta rodada (a ferramenta de navegação deu timeout); a verificação acima é estática/determinística, então o passo 1–3 vale ser conferido no review.

## Riscos

- **Baixo.** Markup puro, sem CSS/JS novo; nenhuma regra de estilo alterada. Áreas sagradas intactas: `<body class="homepage">`, `brusher-demo.min.js` e `images/homepage*.jpg` não foram tocados; tema dark vintage preservado (só classes já existentes).
- `role="main"` segue em `.chat-card` (`index.html:132`) — deliberadamente **não** reposicionado aqui; é assunto da fatia 3 (#60, rodapé), como a issue previu.
- `.how-section` (`css/styles.css:469+`) segue órfã — fora do escopo desta fatia, coberta pelo épico #44.

Mudança estrutural em `index.html` → **Solicito quórum (HANDBOOK §7)**

Closes #59
Refs #44
