### PR TITLE
fix(chat): devolve o texto ao campo quando a chamada à OpenAI falha

### DIFF
--- a/js/mainJs.js
+++ b/js/mainJs.js
@@ -157,7 +157,12 @@
     if (!input) return;
     input.value = text;
     autosizeChatInput(input);
-    input.focus();
+    /* Só devolve o foco se o campo estiver de fato acessível. Com a Gôndola
+       aberta o textarea fica atrás do overlay: focá-lo sequestraria o teclado do
+       modal (a busca pararia de receber o que se digita e o Enter enviaria a
+       mensagem em vez de confirmar o personagem). Ao fechar a Gôndola,
+       closePicker() devolve o foco por conta própria via `lastFocus`. */
+    if (!picker || picker.hidden) input.focus();
   }
 
   function buildSystemPrompt(p) {

--- a/js/mainJs.js
+++ b/js/mainJs.js
@@ -142,6 +142,24 @@
     if (btn)   btn.disabled   = busy;
   }
 
+  /* Altura do textarea acompanhando o conteúdo (mesmo ajuste do handler de `input`). */
+  function autosizeChatInput(el) {
+    if (!el) return;
+    el.style.height = 'auto';
+    el.style.height = Math.min(el.scrollHeight, 120) + 'px';
+  }
+
+  /* Devolve ao campo o texto que não chegou a virar resposta, para o visitante
+     reenviar sem redigitar. Só o caminho de erro real chama isto: o abort por
+     troca de personagem descartou aquela conversa de propósito. */
+  function restoreChatDraft(text) {
+    var input = document.getElementById('chat-input');
+    if (!input) return;
+    input.value = text;
+    autosizeChatInput(input);
+    input.focus();
+  }
+
   function buildSystemPrompt(p) {
     return [
       'Você é ' + p.name + ' (' + p.years + '), ' + p.tagline + '.',
@@ -272,9 +290,10 @@
       })
       .catch(function (err) {
         if (req.cancelled) { done(); return; }    // abort intencional (troca de personagem) — silêncio
-        done();
+        done();                                   // reabilita o campo ANTES de devolver o texto
         hideTyping();
         appendAIMessage(chatErrorMessage(err));
+        restoreChatDraft(msgText);                // reenvio sem redigitar (a bolha de erro continua)
         console.error('[NostalgiaGPT]', err);
       });
   };
@@ -580,8 +599,7 @@
     });
     /* Auto-resize do textarea */
     $(document).on('input', '#chat-input', function () {
-      this.style.height = 'auto';
-      this.style.height = Math.min(this.scrollHeight, 120) + 'px';
+      autosizeChatInput(this);
     });
   });
 


### PR DESCRIPTION
## Contexto

`window.insertMessage` limpa `#chat-input` logo no envio (`js/mainJs.js:205`) e o caminho de erro só imprimia a bolha amigável do `chatErrorMessage()`. Como o #53 (corretamente) deixou de empilhar o turno `user` em `conversation` quando a resposta não chega, o texto digitado não sobrevivia em lugar nenhum recuperável: nem no campo, nem no histórico. Falha de rede/timeout/HTTP = redigitar a mensagem inteira.

## O que mudou e por quê

- `restoreChatDraft(text)` (novo, `js/mainJs.js`): devolve o texto ao `#chat-input`, reajusta a altura do textarea e devolve o foco — o campo volta exatamente ao estado de antes do envio.
- O `catch` chama `restoreChatDraft(msgText)` **depois** de `done()` (que reabilita o campo via `setChatBusy(false)`) e **depois** de `appendAIMessage(chatErrorMessage(err))` — a bolha de erro continua aparecendo, o foco termina no campo.
- O early-return de `req.cancelled` (abort intencional por troca de personagem) fica **intocado**: continua silencioso e **não** restaura nada.
- `autosizeChatInput(el)` (novo): extrai o ajuste `height:auto` + `min(scrollHeight,120)` que estava inline no handler de `input`, para que envio e restauração não divirjam. O handler passa a chamá-lo — mesmo comportamento, uma fonte só.

Nada tocado no lock (`pending`), em `conversation` (nenhum turno órfão — a garantia do #53 permanece), no Brusher ou no tema.

## Gate

```
node scripts/gate.mjs
GATE VERDE — 19/19 checagens passaram.
```

## Teste manual

Requer chave real em `OPENAI_KEY` (com o placeholder o fluxo cai em `isDemoWithoutKey()` e nem chega ao `fetch`).

1. Abrir o chat, digitar uma mensagem **com quebras de linha** (Shift+Enter) e enviar com a rede desligada (DevTools → Network → Offline).
2. Esperado: bolha `📡 Não consegui falar com a OpenAI…`, campo habilitado com o texto **idêntico** (quebras preservadas), altura do textarea correta, cursor no campo; Enter reenvia sem redigitar.
3. Repetir com chave inválida (401) e com timeout (`OPENAI_TIMEOUT`) — mesmo resultado.
4. Enviar e, **antes da resposta**, trocar de personagem na gôndola: nada de bolha de erro e o campo continua vazio (abort intencional).

## Riscos

- Baixo. Diff restrito ao caminho de erro de `window.insertMessage` mais a extração do autosize.
- `input.focus()` abre o teclado virtual em mobile após uma falha; é o mesmo estado em que o campo estava antes do envio, e o alvo é justamente o reenvio.
- Toca o fluxo do chat em `mainJs.js` → **Solicito quórum (HANDBOOK §7)**

Closes #56
