### PR TITLE
feat(ui): restaura o rodapé da landing e corrige o landmark main (#60)

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,6 +87,9 @@
   <!-- ═══ Efeito de fundo "Brusher" (esfumaçado / revelar) ═══ -->
   <script src="brusher-demo.min.js"></script>
 
+  <!-- Landmark principal: hero + chat + galeria (o rodapé fica fora) -->
+  <main>
+
   <!-- ═══════════════════ HERO ═══════════════════ -->
   <section class="hero" aria-label="Apresentação">
     <div class="hero-content">
@@ -129,7 +132,7 @@
   <section class="chat-section" id="chat" aria-label="Interface de chat">
     <div class="chat-section-bg" aria-hidden="true"></div>
     <div class="chat-container">
-      <div class="chat-card" role="main">
+      <div class="chat-card">
 
         <!-- Personality Bar -->
         <div class="personality-bar" role="banner">
@@ -259,6 +262,30 @@
       </div>
     </div>
   </section>
+
+  </main>
+
+  <!-- ═══════════════════ RODAPÉ ═══════════════════ -->
+  <footer class="footer">
+    <div class="footer-container">
+      <p class="footer-logo">
+        <img src="favicon-32.png" alt="" width="22" height="22">
+        NostalgiaGPT
+      </p>
+      <p class="footer-tagline">Um salão de vozes que o tempo não calou.</p>
+      <nav class="footer-links" aria-label="Links do projeto">
+        <a href="https://github.com/caioross/NostalgiaGPT" target="_blank" rel="noopener">Repositório</a>
+        <span class="footer-sep" aria-hidden="true">·</span>
+        <a href="https://github.com/caioross/NostalgiaGPT/blob/main/LICENSE" target="_blank" rel="noopener">Licença MIT</a>
+        <span class="footer-sep" aria-hidden="true">·</span>
+        <a href="https://github.com/caioross/NostalgiaGPT/blob/main/ATTRIBUTION.md" target="_blank" rel="noopener">Créditos de terceiros</a>
+      </nav>
+      <p class="footer-credit">
+        Feito com <span role="img" aria-label="amor">♥</span> por
+        <a href="https://github.com/caioross" target="_blank" rel="noopener">Caio Ross</a> — código sob licença MIT.
+      </p>
+    </div>
+  </footer>
 
   <!-- ═══════════════════ MODAL: GÔNDOLA ═══════════════════ -->
   <div class="picker-overlay" id="picker" hidden>


### PR DESCRIPTION
## Contexto

Fatia 3 (última) do épico #44. A landing terminava abruptamente na gôndola — sem crédito, sem licença e sem link para o repositório — e as 19 regras `.footer*` de `css/styles.css:498-516` estavam órfãs. Além disso, o `role="main"` vivia no `.chat-card`, o que deixava hero e galeria **fora** do landmark principal.

## O que mudou (só `index.html`, 28 linhas +, 1 −)

- **`<footer class="footer">`** inserido depois da galeria e **fora** do `.picker-overlay`, usando exatamente as classes que o CSS já define: `.footer-container`, `.footer-logo` (+ `img`), `.footer-tagline`, `.footer-links` (+ `.footer-sep`) e `.footer-credit` (o `<span>` do coração pega o `#b44` que o CSS já reservava).
- **Landmark**: `<main>` passa a envolver hero + chat + galeria e o `role="main"` saiu do `.chat-card`. Um único `main` na página, `<footer>` fora dele.
- **Zero CSS novo, zero JS novo.**

### Duas decisões que fogem da letra da issue (ambas justificadas)

1. **Logo = `favicon-32.png`, não `icon.png`.** O `icon.png` pesa **1,69 MB**; para um logo de 22 px isso são 1,69 MB no caminho de renderização de uma página que já é alvo das issues de peso #33 e #62. O `favicon-32.png` tem **2,2 KB**, é 32×32 e já vem do cache (a página o carrega em `<link rel="icon">`). `width`/`height` explícitos no HTML, como pedia a dica da issue, para não gerar layout shift.
2. **O miolo do `<main>` não foi reindentado.** Reindentar as três seções somaria ~175 linhas de diff puramente de whitespace e tornaria a revisão do quórum inviável. Optei pelo diff auditável; os separadores `<!-- ═══ ... ═══ -->` já delimitam as seções.

Os links de `LICENSE` e `ATTRIBUTION.md` apontam para o blob no GitHub (renderizado) em vez do arquivo servido pelo Pages, que o browser trataria como download de texto puro. Todos com `target="_blank" rel="noopener"`.

## Gate (resultado real)

```
$ node scripts/gate.mjs
GATE VERDE — 19/19 checagens passaram.
```

Verificações extras no worktree:

```
h1 count: 1                 # exatamente um <h1> na página
<main> / </main>: 1 par     # nenhum role="main" restante
footer (269-288) < picker-overlay (291)   # rodapé fora do modal
.footer, .footer-container, .footer-logo, .footer-tagline,
.footer-links, .footer-sep, .footer-credit → todas com uso no HTML
```

## Teste manual sugerido (mudança visual)

Abrir `index.html` direto no browser (zero-build): rolar até o fim — o rodapé aparece sob a galeria, centralizado (máx. 540 px), com borda dourada no topo e fundo `rgba(6,6,11,0.86)`; os três links ficam em linha separados por `·` e passam a dourado no hover. Abrir a Gôndola e confirmar que o modal continua cobrindo a tela sem o rodapé vazar por dentro dele.

## Riscos

- **Baixo.** Diff só de markup; nenhuma regra de CSS ou linha de JS tocada.
- Brusher intacto: `<body class="homepage">`, `brusher-demo.min.js` e `images/homepage*.jpg` inalterados (gate confirma as 3 invariantes).
- O `<main>` é um wrapper `display:block` num `<body>` que não é flex/grid — não altera o fluxo nem as camadas `z-index:-1` do Brusher.
- Mudança estrutural em `index.html` → **quórum §7.2**, conforme a própria issue avisa.

**Solicito quórum (HANDBOOK §7)**

Closes #60
Closes #44
