### PR TITLE
docs(github): templates de issue e de PR que materializam o HANDBOOK

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,82 @@
+name: 🐞 Bug
+description: Algo do site está quebrado ou se comporta de forma errada.
+title: "Bug: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Obrigado por relatar. Quanto mais concreto o relato, mais rápido ele vira correção.
+
+        ⚠️ **Nunca cole chaves de API, tokens ou dados pessoais** aqui — esta issue é pública.
+        Suspeita de vulnerabilidade ou de segredo exposto? Não descreva o vetor em público:
+        abra um contato mínimo com o dono do repositório antes.
+
+  - type: textarea
+    id: descricao
+    attributes:
+      label: O que está acontecendo
+      description: Descreva o comportamento errado em uma ou duas frases.
+      placeholder: Ao abrir a gôndola, o card selecionado fica atrás dos vizinhos.
+    validations:
+      required: true
+
+  - type: textarea
+    id: passos
+    attributes:
+      label: Passos para reproduzir
+      description: Passo a passo, do zero, na URL pública (https://caioross.github.io/NostalgiaGPT/).
+      placeholder: |
+        1. Abrir https://caioross.github.io/NostalgiaGPT/
+        2. Clicar em "Escolher personalidade"
+        3. Arrastar a gôndola para a esquerda
+        4. Ver o card central sumir atrás do vizinho
+    validations:
+      required: true
+
+  - type: textarea
+    id: esperado
+    attributes:
+      label: Comportamento esperado
+      description: O que deveria acontecer no lugar.
+    validations:
+      required: true
+
+  - type: input
+    id: ambiente
+    attributes:
+      label: Navegador e sistema operacional
+      description: Inclua a versão. Se for no celular, diga o aparelho.
+      placeholder: Chrome 127 · Windows 11 · desktop 1920×1080
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Área afetada
+      description: Áreas oficiais do projeto (HANDBOOK §3). Na dúvida, escolha a mais próxima — a triagem ajusta.
+      options:
+        - "area:conteudo — personalidades, prompts, historicidade"
+        - "area:chat — mainJs, OpenAI, robustez, erros"
+        - "area:ui — tema, galeria, gôndola, responsivo, SEO/OG"
+        - "area:seguranca — XSS, segredos, escape"
+        - "area:a11y — acessibilidade"
+        - "area:perf-assets — imagens, peso da página, carregamento"
+        - "area:docs — README, documentação"
+        - "area:infra — git, gate, frota, tooling"
+    validations:
+      required: true
+
+  - type: input
+    id: contexto
+    attributes:
+      label: Contexto no código (opcional)
+      description: Se souber onde o problema mora, aponte `arquivo:linha`.
+      placeholder: js/mainJs.js:412
+
+  - type: textarea
+    id: extras
+    attributes:
+      label: Evidência (opcional)
+      description: Print, GIF ou o erro do console do navegador (F12 → Console). Cole o texto do erro, não a página inteira.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💡 Tenho uma ideia / sugestão de funcionalidade
+    url: https://github.com/caioross/NostalgiaGPT/discussions/new?category=ideas
+    about: Ideias passam primeiro por Discussions/Ideas e por uma triagem ICE — as bem avaliadas viram issue. Abrir ideia como issue atrasa a sua proposta.
+  - name: ❓ Dúvida de uso do site ou do chat
+    url: https://github.com/caioross/NostalgiaGPT/discussions/new?category=q-a
+    about: Perguntas sobre como usar o NostalgiaGPT são respondidas em Discussions/Q&A.
+  - name: 📖 Como este repositório funciona (HANDBOOK da frota)
+    url: https://github.com/caioross/NostalgiaGPT/blob/main/docs/fleet/HANDBOOK.md
+    about: Prioridades, áreas, gate obrigatório e o que só o dono decide. Leitura recomendada antes de abrir issue ou PR.

--- a/.github/ISSUE_TEMPLATE/personalidade.yml
+++ b/.github/ISSUE_TEMPLATE/personalidade.yml
@@ -1,0 +1,103 @@
+name: 🎩 Personalidade — sugerir ou corrigir
+description: Propor uma nova personalidade histórica, ou corrigir dados de uma existente.
+title: "Conteúdo: "
+labels: ["area:conteudo"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        As 47 personalidades vivem em `js/personalities.js` — a fonte única de verdade do conteúdo.
+        Cada uma é **uma linha** do array `PEOPLE` no formato `{ name, cat, years, tagline, img }`.
+
+        Não preencha `slug` nem `initials`: eles são **derivados em runtime** pelo próprio arquivo.
+
+  - type: dropdown
+    id: tipo
+    attributes:
+      label: Tipo de contribuição
+      options:
+        - Nova personalidade
+        - Correção de dados de uma personalidade existente
+    validations:
+      required: true
+
+  - type: input
+    id: name
+    attributes:
+      label: "`name` — nome exibido"
+      description: Exatamente como deve aparecer no card. Acentuação correta.
+      placeholder: Marie Curie
+    validations:
+      required: true
+
+  - type: dropdown
+    id: cat
+    attributes:
+      label: "`cat` — categoria"
+      description: São as 6 categorias existentes. Não criamos categoria nova por personalidade.
+      options:
+        - "ciencia — Ciência & Tecnologia"
+        - "arte — Arte & Literatura"
+        - "filosofia — Filosofia & Fé"
+        - "lideres — Líderes & Política"
+        - "musica — Música"
+        - "lendas — Esporte & Lendas"
+    validations:
+      required: true
+
+  - type: input
+    id: years
+    attributes:
+      label: "`years` — período de vida"
+      description: "Formato do arquivo, com travessão: `1867–1934`. Antes de Cristo: `428–348 a.C.`"
+      placeholder: 1867–1934
+    validations:
+      required: true
+
+  - type: input
+    id: tagline
+    attributes:
+      label: "`tagline` — legenda curta"
+      description: Até ~30 caracteres; é o que aparece sob o nome no card.
+      placeholder: Pioneira da Radioatividade
+    validations:
+      required: true
+
+  - type: textarea
+    id: historicidade
+    attributes:
+      label: Por que esta pessoa, e com que fontes
+      description: Relevância histórica e ao menos uma fonte verificável para as datas e a legenda. Anacronismo e biografia inventada são motivo de recusa.
+      placeholder: |
+        Duas vezes laureada com o Nobel (Física 1903, Química 1911).
+        Fonte: https://www.nobelprize.org/prizes/physics/1903/marie-curie/facts/
+    validations:
+      required: true
+
+  - type: textarea
+    id: foto
+    attributes:
+      label: "`img` — foto (opcional)"
+      description: |
+        Sem foto o site gera um monograma automático — isso é aceitável e é o caso da maioria.
+        Se propuser foto, informe a **origem e a licença** (domínio público ou licença compatível) e o link para o original.
+        Não anexe arquivo cuja licença você não conheça.
+      placeholder: |
+        Origem: Wikimedia Commons — https://commons.wikimedia.org/wiki/File:....jpg
+        Licença: domínio público (autor falecido há mais de 70 anos)
+
+  - type: textarea
+    id: starters
+    attributes:
+      label: "`starters` — perguntas de abertura (opcional)"
+      description: Até 3 perguntas em PT-BR, na segunda pessoa, sobre fatos da vida da pessoa. Sem anacronismo.
+      placeholder: |
+        Como foi isolar o rádio no galpão da Rue Lhomond?
+        O que sentiu ao receber o segundo Nobel?
+
+  - type: markdown
+    attributes:
+      value: |
+        ---
+        Se você mesmo for abrir o PR: edite **uma linha** no array `PEOPLE`, mantendo o alinhamento
+        das colunas vizinhas, e rode `node scripts/gate.mjs` antes de enviar.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,45 @@
+<!--
+  Obrigado por contribuir com o NostalgiaGPT.
+  Este repositório é PÚBLICO e a branch `main` é produção (GitHub Pages).
+  Preencha os campos abaixo — o resultado real do gate é obrigatório.
+-->
+
+## O que mudou e por quê
+
+<!-- Uma ou duas frases. Se resolve uma issue, diga qual problema dela some com este diff. -->
+
+## Issue relacionada
+
+<!-- `Closes #N` SÓ se este PR resolve a issue INTEIRA. Fatia parcial usa `Refs #N`. -->
+
+Refs #
+
+## Resultado do gate
+
+O gate é obrigatório e roda sem instalar nada:
+
+```bash
+node scripts/gate.mjs
+```
+
+<details>
+<summary>Saída real do comando (cole abaixo)</summary>
+
+```
+(cole aqui a saída, não um resumo)
+```
+
+</details>
+
+## Riscos e como testei
+
+<!-- O que pode quebrar, e o que você abriu no navegador para confirmar que não quebrou. -->
+
+## Checklist
+
+- [ ] `node scripts/gate.mjs` está **verde** e a saída real está colada acima.
+- [ ] Não toquei no efeito **Brusher** nem no **tema dark vintage dourado** (áreas sagradas — HANDBOOK §2).
+- [ ] Não adicionei bundler, framework, `npm install` nem dependência externa (o projeto é **zero-build**).
+- [ ] Nenhum segredo no diff: `OPENAI_KEY` continua com o placeholder e nenhum `.env` foi versionado.
+- [ ] Conteúdo dinâmico novo passa por `esc()` antes de ir ao DOM.
+- [ ] Diff mínimo, sem refactor oportunista.


### PR DESCRIPTION
## Contexto

`.github/` tinha **um único arquivo** (`workflows/gate.yml`). Sem templates, issue de fora chega sem prioridade nem área, ideia entra como issue em vez de ir para Discussions/Ideas, e PR chega sem o resultado do gate — tudo o que o HANDBOOK §3/§9 exige só existia na cabeça da frota.

## O que mudou e por quê

Quatro arquivos novos, só texto — nenhum `js/`, `css/` ou `index.html` foi tocado. Os templates **não inventam processo**: materializam o HANDBOOK.

- **`.github/ISSUE_TEMPLATE/config.yml`** — `blank_issues_enabled: false` + 3 `contact_links`: Discussions/Ideas (ideias, que passam pelo ICE do §9), Discussions/Q&A (dúvidas de uso) e o próprio HANDBOOK. As duas categorias foram confirmadas como existentes no repo antes de linkar.
- **`.github/ISSUE_TEMPLATE/bug.yml`** — issue **form**: descrição, passos para reproduzir, esperado, navegador/SO (obrigatórios), `dropdown` de área com **exatamente** as 8 do §3, mais `arquivo:linha` e evidência opcionais. `labels: [bug]`.
- **`.github/ISSUE_TEMPLATE/personalidade.yml`** — o caso mais provável de contribuição externa. Pede `name`, `cat` (dropdown com as 6 categorias reais), `years` (com o travessão do arquivo), `tagline`, fontes de historicidade e origem/licença da foto; `starters` opcional. Diz explicitamente que **`slug` e `initials` são derivados em runtime** e não se escrevem à mão. `labels: [area:conteudo]`.
- **`.github/pull_request_template.md`** — o quê/por quê, `Closes #N` vs `Refs #N`, bloco para colar a **saída real** de `node scripts/gate.mjs`, riscos, e checklist com Brusher + tema dourado intactos, zero-build, `OPENAI_KEY` placeholder e `esc()` no conteúdo dinâmico.

Decisões tomadas na rodada: nenhum template de "feature request" (esse fluxo é Discussions/Ideas + ICE, §9); todas as `labels:` conferidas contra `gh label list` — as 8 áreas do dropdown batem caractere a caractere com as labels existentes, então nada falha em silêncio.

## Resultado do gate (real)

```
$ node scripts/gate.mjs
=== GATE NostalgiaGPT ===
  [OK] arquivo presente: index.html
  ... (19 checagens)
  [OK] nenhum segredo real em arquivos rastreados
  [OK] OPENAI_KEY = placeholder (correto para versionar)

GATE VERDE — 19/19 checagens passaram.
```

Validação extra dos forms (o gate não cobre YAML): os três `.yml` foram parseados e verificados estruturalmente — `name`/`description` presentes, todo campo não-`markdown` com `label` e `id`, ids únicos, `dropdown` com `options`, `validations` só com `required`, e `contact_links` com `name`/`url`/`about`.

## Riscos

Baixo: nenhum arquivo servido pelo site muda, então não há como afetar produção (Pages). O risco residual é um form ser recusado pelo GitHub por schema — mitigado pela validação estrutural acima; o efeito visível, se houvesse, seria só a página `issues/new/choose`, corrigível em minutos.

Verificação pós-merge (último acceptance criterion, só observável depois): abrir <https://github.com/caioross/NostalgiaGPT/issues/new/choose> e conferir as duas opções + os três links de Discussions/HANDBOOK.

**Fora de escopo, para o dono:** o item 4 do contexto da issue (canal para relato de segurança) não tem acceptance criterion e não dá para resolver por arquivo — depende de habilitar *Private vulnerability reporting* nas configurações do repositório, o que é núcleo §7.1. Enquanto isso, o `bug.yml` ao menos avisa para não descrever vetor de vulnerabilidade em público.

Solicito quórum (HANDBOOK §7)

`.github/*` cai no §7.2 — merge só com as 3 lentes (Técnica, Segurança, Produto).

Closes #67
