### PR TITLE
fix(css): corrige caminho do fundo do Brusher, relativo ao styles.css

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -52,7 +52,7 @@ body {
    A imagem borrada fica no body; o brusher-demo.min.js cria
    as camadas fixas (nítida + canvas "escovável") em z-index:-1. */
 body.homepage {
-  background-image: url("images/homepage-blurred.jpg");
+  background-image: url("../images/homepage-blurred.jpg");
   background-size: cover;
   background-position: center;
   background-attachment: fixed;


### PR DESCRIPTION
## Contexto

`css/styles.css:55` declarava a camada base do efeito Brusher como `url("images/homepage-blurred.jpg")`. URLs em CSS resolvem **relativas ao arquivo CSS**, não ao documento — como a regra vive em `css/`, o browser pedia `css/images/homepage-blurred.jpg`, que não existe (`css/` contém só `styles.css`). O arquivo real está em `images/`, na raiz.

Resultado: 404, e o fundo esfumaçado do Brusher não aparecia. `main` = produção (HANDBOOK §2), então isto estava no ar em <https://caioross.github.io/NostalgiaGPT/>.

## O que mudou

Uma linha, `css/styles.css:55`:

```diff
-  background-image: url("images/homepage-blurred.jpg");
+  background-image: url("../images/homepage-blurred.jpg");
```

Nada mais. Nenhum arquivo de `images/` movido, renomeado ou recomprimido (o caminho `images/homepage.jpg` está hardcoded no bundle vendorizado). `brusher-demo.min.js` e `index.html` intocados. É a **única** `url()` de todo o CSS — confirmado com `grep -n 'url(' css/styles.css`.

## Área sagrada

Isto **não** mexe no efeito Brusher (HANDBOOK §2.1/§7.1) — conserta um caminho quebrado para que ele volte a aparecer como projetado. Tema dark vintage e zero-build intactos. Classificação: **§7.3 normal**.

## Verificação manual (antes/depois)

Worktree servido por HTTP local em `localhost:8172`, lendo a aba de rede — mesmo servidor, mesma página, alternando só esta linha:

| Estado | Requisição | Resultado |
|---|---|---|
| **Antes** (`b19ff56`, = `origin/main`) | `GET /css/images/homepage-blurred.jpg` | **404 Not Found** |
| **Depois** (este commit) | `GET /images/homepage-blurred.jpg` | **200 OK** |

`getComputedStyle(document.body).backgroundImage` no estado "depois":

```
url("http://localhost:8172/images/homepage-blurred.jpg")
```

com `body.className === "homepage"` e `background-attachment: fixed` preservados.

Não foi possível anexar screenshot: o Browser pane roda sem composição nesta sessão agendada (`screenshot` expira). A evidência acima é de rede + estilo computado, que é o que o acceptance criteria pede como verificável.

## Gate

```
node scripts/gate.mjs
GATE VERDE — 19/19 checagens passaram.
```

Rodado no worktree, com o patch aplicado.

## Riscos

Baixo. Uma propriedade CSS, sem efeito em JS, layout ou z-index. O pior caso de um caminho errado seria o 404 que já existe hoje — e a verificação acima descarta isso.

Observação honesta, **não relacionada e pré-existente**: o console do Brusher emite `InvalidStateError: drawImage ... canvas with a width or height of 0` neste ambiente headless. Reproduz **idêntico** antes e depois do patch (medido nas duas passagens acima), portanto não é regressão desta PR. Não investiguei além disso por estar fora do escopo.

## Escopo

O acceptance criteria trazia um item "desejável" de adicionar ao gate uma checagem que resolva `url(...)` relativa ao próprio CSS. Mexer no gate cai em **quórum §7.2**, e a issue previa explicitamente a fatia — está registrado em #75. Esta PR fica só com a correção do caminho, que é o que a #72 pede como obrigatório.

Closes #72
