### PR TITLE
fix(css): wordmark do hero deixa de ser cortado abaixo de 576px

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -683,7 +683,11 @@ button { font-family: var(--font-body); cursor: pointer; }
 @media (max-width: 680px) {
   .nav { padding: 1.25rem 1.25rem; }
   .nav-logo span { display: none; }
-  .hero-title { font-size: clamp(2.8rem, 15vw, 4.5rem); }
+  /* O wordmark é uma palavra só (não quebra): em Cinzel 700 a largura do texto
+     é 7,51× o font-size. Com o padding de 24px do .hero-content — e reservando
+     os ~15px da barra de rolagem, que o `vw` não desconta — só cabe até 320px
+     se font-size ≤ (100vw − 63px) / 7,51, daí 10.5vw (e não 15vw). Ver #77. */
+  .hero-title { font-size: clamp(2rem, 10.5vw, 4.5rem); }
   .hero-actions { flex-direction: column; align-items: stretch; }
 
   .personality-bar { gap: 0.7rem; padding: 0.85rem 0.9rem; flex-wrap: wrap; }


### PR DESCRIPTION
## Contexto

O `<h1>` do hero (`index.html:97`) é uma **palavra única sem ponto de quebra** — nenhuma largura de container resolve, só o `font-size`. O bloco mobile (`css/styles.css:686`) pedia `clamp(2.8rem, 15vw, 4.5rem)`, muito acima do que cabe: em 375px o "GPT" ficava ~95px fora da viewport, sintoma escondido pelo `body { overflow-x: hidden }` (`css/styles.css:46`).

## O que mudou

Uma linha, restrita ao bloco `@media (max-width: 680px)`:

```diff
-  .hero-title { font-size: clamp(2.8rem, 15vw, 4.5rem); }
+  .hero-title { font-size: clamp(2rem, 10.5vw, 4.5rem); }
```

**Por que 10.5vw e não o 11vw sugerido na issue:** medi a razão real do wordmark em Cinzel 700 no browser — **7,5065×** o `font-size` (a issue estimou 7,5, confere). Mas o `vw` **não desconta a barra de rolagem vertical**: em 320px a largura útil do `.hero-title` é 257px, não 272px. Com 11vw o texto dá 264px e ainda transbordava **1px em 320px** — medido, não suposto. O 10.5vw dá 252px e passa com folga.

O piso caiu de `2.8rem` para `2rem` porque `2.8rem` (44,8px) sozinho já estourava em 375px, e um piso acima da curva reintroduziria o bug em telas ultra-estreitas.

## Verificação

`node scripts/gate.mjs` no worktree:

```
GATE VERDE — 19/19 checagens passaram.
```

Medição instrumentada em `iframe` por largura (media queries e `vw` reais, Cinzel carregada, `document.fonts.ready` aguardado):

| viewport | font-size | scrollWidth ≤ clientWidth (AC1) | `.title-gpt.right` ≤ innerWidth (AC2) | uma linha (AC3) |
|---|---|---|---|---|
| 320px | 33,60px | ✔ 257 ≤ 257 | ✔ | ✔ |
| 360px | 37,80px | ✔ 297 ≤ 297 | ✔ | ✔ |
| 375px | 39,40px | ✔ 312 ≤ 312 | ✔ | ✔ |
| 390px | 40,99px | ✔ 327 ≤ 327 | ✔ | ✔ |
| 414px | 43,51px | ✔ 351 ≤ 351 | ✔ | ✔ |
| 430px | 45,19px | ✔ 367 ≤ 367 | ✔ | ✔ |
| 480px | 50,40px | ✔ 417 ≤ 417 | ✔ | ✔ |
| 575px | 60,40px | ✔ 512 ≤ 512 | ✔ | ✔ |
| 600px | 63,00px | ✔ 537 ≤ 537 | ✔ | ✔ |
| 680px | 71,40px | ✔ 617 ≤ 617 | ✔ | ✔ |

- **AC4 (desktop inalterado):** o diff não sai do bloco `max-width: 680px` — o bloco base (`css/styles.css:161`) não foi tocado. Nota factual: o AC4 afirma "font-size continua 72px em 1280px"; o valor real medido é **120px** (`clamp(3.2rem, 11vw, 7.5rem)` com `html { font-size: 16px }`, `css/styles.css:39`). O critério "desktop inalterado" está satisfeito de qualquer forma, por construção.
- **AC5:** `body { overflow-x: hidden }` **não foi removido nem usado como correção** — segue intocado.

## Riscos

Baixo. CSS puro, uma propriedade, faixa <680px. O wordmark fica visivelmente menor no celular (39px em vez de 56px em 375px) — é o preço de caber inteiro, e o teto `4.5rem` preserva o tamanho da faixa 600–680px.

## Achados colaterais (fora do escopo, não tocados)

1. **Transbordo do wordmark também no desktop:** em 1024px e 1280px o `.hero-title` tem `scrollWidth` 846/901 contra `clientWidth` 732 (o `.hero-content` tem `max-width: 780px`). Não corta nada visualmente — o `<h1>` centralizado transborda para dentro da viewport, que é larga o bastante — e não gera scroll horizontal. Fora do AC desta issue e vetado pelo AC4; fica o registro para triagem.
2. **Scroll horizontal em 414–480px:** `document.scrollWidth` = 484 contra viewport de 465. A origem são os `.p-card` da galeria (`.group-grid { grid-template-columns: 1fr 1fr }` no mesmo bloco mobile), não o hero. Preexistente a este PR e mascarado pelo mesmo `overflow-x: hidden`.

Closes #77
